### PR TITLE
Parking: Initial transformation to BIG IoT format

### DIFF
--- a/components/LoadSchema.js
+++ b/components/LoadSchema.js
@@ -1,0 +1,62 @@
+const noflo = require('noflo');
+
+const ParkingSpaceOffering = {
+  title: 'ParkingSpaceOffering',
+  type: 'array',
+  items: {
+    type: 'object',
+    properties: {
+      'Latitude': { 
+        type: 'number',
+        example: 48.25,
+        minimum: -90,
+        maximum: -90,
+      },
+      'Longitude': {
+        type: 'number',
+        example: 11.63,
+        minimum: -90,
+        maximum: -90,
+      },
+      'status': {
+        type: 'string',
+        'enum': [ 'available', 'unknown' ], 
+      },
+    }
+  }
+}
+
+const schemas = {
+    'bigiot/ParkingSpaceOffering': ParkingSpaceOffering, 
+}
+
+exports.getComponent = function() {
+  var c = new noflo.Component();
+  c.description = 'Load a named schema';
+  c.icon = 'forward';
+  c.inPorts.add('in', {
+    datatype: 'string',
+    description: 'JSON schema identifier'
+  });
+  c.outPorts.add('out', {
+    datatype: 'object'
+  });
+  c.outPorts.add('error', {
+    datatype: 'object'
+  });
+
+  c.process(function (input, output) {
+    if (!input.hasData('in')) {
+      return;
+    }
+    const name = input.getData('in');
+    const found = schemas[name];
+    if (!found) {
+      return output.error(new Error(`Could not find schema named $(name)`));
+    }
+    output.sendDone({ out: found, });
+  });
+
+  return c;
+};
+

--- a/components/LoadSchema.js
+++ b/components/LoadSchema.js
@@ -5,18 +5,19 @@ const ParkingSpaceOffering = {
   type: 'array',
   items: {
     type: 'object',
+    required: ['Latitude', 'Longitude', 'status'],
     properties: {
       'Latitude': { 
         type: 'number',
         example: 48.25,
         minimum: -90,
-        maximum: -90,
+        maximum: 90,
       },
       'Longitude': {
         type: 'number',
         example: 11.63,
         minimum: -90,
-        maximum: -90,
+        maximum: 90,
       },
       'status': {
         type: 'string',

--- a/components/NormalizeParkingData.js
+++ b/components/NormalizeParkingData.js
@@ -1,0 +1,61 @@
+const noflo = require('noflo');
+
+exports.getComponent = function() {
+  var c = new noflo.Component();
+  c.description = 'Normalize parking data to conform to standardized BIGIoT format';
+  c.icon = 'forward';
+  c.inPorts.add('in', {
+    datatype: 'object',
+    description: 'Raw data from BahnPark API'
+  });
+  c.outPorts.add('out', {
+    datatype: 'object',
+    description: 'BIGIoT formatted data'
+  });
+  c.outPorts.add('error', {
+    datatype: 'object'
+  });
+
+  c.process(function (input, output) {
+    if (!input.hasData('in')) {
+      return;
+    }
+    const indata = input.getData('in');
+
+    if (!indata.allocations) {
+        return output.error(new Error("BahnPark data missing .allocations"));
+    }
+
+    function fromBahnparkAllocation(a) {
+        var status = 'unknown';
+        if (a.allocation.category === 0) {
+            status = 'unavailable';
+        } else if (a.allocation.category >= 1) {
+            status = 'available';
+        }
+        // NOTE: there is also a timeSegment? timeSegment seems rounded to 5 mins
+        const o = {
+            id: a.space.id,
+            lastUpdated: a.allocation.timestamp,
+            status: status,
+            title: a.space.title,
+        }
+        return o;
+    }
+
+    function allocationIsValid(a) {
+        const hasId = (a.space && typeof a.space.id == 'number');
+        const hasCapacity = (a.allocation && typeof a.allocation.capacity == 'number' && a.allocation.capacity > 0);
+        return hasId && hasCapacity;
+    }
+
+    const out = indata.allocations
+        .filter(allocationIsValid)
+        .map(fromBahnparkAllocation);
+
+    output.sendDone({ out: out, });
+  });
+
+  return c;
+};
+

--- a/components/ValidateData.js
+++ b/components/ValidateData.js
@@ -1,0 +1,47 @@
+const tv4 = require('tv4');
+const noflo = require('noflo');
+
+exports.getComponent = function() {
+  var c = new noflo.Component();
+  c.description = 'Validate data against JSON schema';
+  c.icon = 'forward';
+  c.inPorts.add('schema', {
+    datatype: 'object',
+    description: 'Fully-resolved JSON schema'
+  });
+  c.inPorts.add('in', {
+    datatype: 'all',
+    description: 'Data to validate'
+  });
+  c.outPorts.add('error', {
+    datatype: 'object',
+  });
+  c.outPorts.add('errors', {
+    datatype: 'array',
+    description: 'Array of errors. If valid will be empty',
+  });
+  c.process(function (input, output) {
+    // Check preconditions on input data
+    if (!input.hasData('schema', 'in')) {
+      return;
+    }
+    // Read packets we need to process
+    const schema = input.getData('schema');
+    const data = input.getData('in');
+
+    const result = tv4.validateMultiple(data, schema);
+
+    if (result.missing.length > 0) {
+      return output.error(new Error(`Missing schema references: $(result.missing)`));
+    }
+
+    // Sanity check that errors always set if not valid
+    if (!result.valid !== (result.errors.length > 0)) {
+      return output.error(new Error(`ValidateData post-condition failed: isInvalid == hasErrors`))
+    }
+
+    output.sendDone({ errors: result.errors, });
+  });
+  return c;
+};
+

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "fbp": "^1.5.0",
     "noflo": "^0.8.5",
     "noflo-core": "^0.4.0",
-    "noflo-nodejs": "^0.8.1"
+    "noflo-filesystem": "^1.1.1",
+    "noflo-nodejs": "^0.8.1",
+    "noflo-objects": "^0.3.0",
+    "noflo-strings": "^0.3.0"
   },
   "devDependencies": {
     "fbp-spec": "^0.2.1"

--- a/spec/ParkingProvider.yaml
+++ b/spec/ParkingProvider.yaml
@@ -3,24 +3,34 @@ topic: "flowhub-bigiot-bridge/NormalizeParkingData"
 fixture:
  type: 'fbp'
  data: |
-  INPORT=read.IN:filename
+  INPORT=read.IN:occupancy
+  INPORT=readSpaces.IN:spaces
   OUTPORT=validate.ERRORS:validationerrors
   OUTPORT=errors.OUT:error
 
-  read(filesystem/ReadFile) -> parse(strings/ParseJson)
-  'bigiot/ParkingSpaceOffering' -> schema(LoadSchema) -> SCHEMA validate(ValidateData)
-  
-  parse -> testee(NormalizeParkingData) -> validate
+  read(filesystem/ReadFile) -> occupancy(strings/ParseJson)
+  readSpaces(filesystem/ReadFile) -> spaces(strings/ParseJson)
+  '!' -> START (objects/CreateObject) -> mergeOccupancy(objects/SetPropertyValue) -> mergeSpaces(objects/SetPropertyValue)
+  'occupancy' -> PROPERTY mergeOccupancy
+  occupancy -> VALUE mergeOccupancy
+  'spaces' -> PROPERTY mergeSpaces
+  spaces -> VALUE mergeSpaces
+
+  mergeSpaces -> testee(NormalizeParkingData) -> validate(ValidateData)
+  'bigiot/ParkingSpaceOffering' -> schema(LoadSchema) -> SCHEMA validate
 
   read ERROR -> errors(core/Repeat)  
-  parse ERROR -> errors
+  readSpaces ERROR -> errors
+  occupancy ERROR -> errors
+  spaces ERROR -> errors
   schema ERROR -> errors
 cases:
 -
   name: 'with known-good API data'
   assertion: 'output should be valid'
   inputs:
-    filename: 'spec/data/bahnpark/occupancies-13.23-26.09.2017.json'
+    spaces: 'spec/data/bahnpark/spaces-26.09.2017.json'
+    occupancy: 'spec/data/bahnpark/occupancies-13.23-26.09.2017.json'
   expect:
     validationerrors:
       equals: []

--- a/spec/ParkingProvider.yaml
+++ b/spec/ParkingProvider.yaml
@@ -1,0 +1,26 @@
+name: "Parking data transformation"
+topic: "flowhub-bigiot-bridge/NormalizeParkingData"
+fixture:
+ type: 'fbp'
+ data: |
+  INPORT=read.IN:filename
+  OUTPORT=validate.ERRORS:validationerrors
+  OUTPORT=errors.OUT:error
+
+  read(filesystem/ReadFile) -> parse(strings/ParseJson)
+  'bigiot/ParkingSpaceOffering' -> schema(LoadSchema) -> SCHEMA validate(ValidateData)
+  
+  parse -> testee(NormalizeParkingData) -> validate
+
+  read ERROR -> errors(core/Repeat)  
+  parse ERROR -> errors
+  schema ERROR -> errors
+cases:
+-
+  name: 'with known-good API data'
+  assertion: 'output should be valid'
+  inputs:
+    filename: 'spec/data/bahnpark/occupancies-13.23-26.09.2017.json'
+  expect:
+    validationerrors:
+      equals: []

--- a/spec/data/bahnpark/occupancies-13.23-26.09.2017.json
+++ b/spec/data/bahnpark/occupancies-13.23-26.09.2017.json
@@ -1,0 +1,820 @@
+{
+   "allocations" : [ {
+      "space" : {
+         "id" : 100035,
+         "title" : "Bonn Hbf P1 Bonn Hbf P1 Parkhaus",
+         "station" : {
+            "id" : 767,
+            "name" : "Bonn Hbf"
+         },
+         "label" : "P1",
+         "name" : "Parkhaus Bonn Hauptbahnhof",
+         "nameDisplay" : "Bonn Hbf P1 Parkhaus"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:24:00",
+         "timeSegment" : "2017-09-26T13:20:00",
+         "capacity" : 110,
+         "category" : 3,
+         "text" : "> 30"
+      }
+   }, {
+      "space" : {
+         "id" : 100291,
+         "title" : "Ulm Hbf P2 Ulm Hbf P2 Parkplatz",
+         "station" : {
+            "id" : 6323,
+            "name" : "Ulm Hbf"
+         },
+         "label" : "P2",
+         "name" : "Parkplatz Ulm Hauptbahnhof",
+         "nameDisplay" : "Ulm Hbf P2 Parkplatz"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:23:00",
+         "timeSegment" : "2017-09-26T13:20:00",
+         "capacity" : 115,
+         "category" : 2,
+         "text" : "> 10"
+      }
+   }, {
+      "space" : {
+         "id" : 100103,
+         "title" : "Göttingen P2 Göttingen P2 Parkhaus",
+         "station" : {
+            "id" : 2218,
+            "name" : "Göttingen"
+         },
+         "label" : "P2",
+         "name" : "Parkhaus am Bahnhof",
+         "nameDisplay" : "Göttingen P2 Parkhaus"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:25:48",
+         "timeSegment" : "2017-09-26T13:25:00",
+         "capacity" : 314,
+         "category" : 4,
+         "text" : "> 50"
+      }
+   }, {
+      "space" : {
+         "id" : 100102,
+         "title" : "Göttingen P1 Göttingen P1 Parkplatz",
+         "station" : {
+            "id" : 2218,
+            "name" : "Göttingen"
+         },
+         "label" : "P1",
+         "nameDisplay" : "Göttingen P1 Parkplatz"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:25:48",
+         "timeSegment" : "2017-09-26T13:25:00",
+         "capacity" : 97,
+         "category" : 2,
+         "text" : "> 10"
+      }
+   }, {
+      "space" : {
+         "id" : 100169,
+         "title" : "Kassel-Wilhelmshöhe P1 Kassel Wilhelmshöhe P1 Parkplatz",
+         "station" : {
+            "id" : 3127,
+            "name" : "Kassel-Wilhelmshöhe"
+         },
+         "label" : "P1",
+         "name" : "Parkplatz Bahnhof Kassel-Wilhelmshöhe",
+         "nameDisplay" : "Kassel Wilhelmshöhe P1 Parkplatz"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:25:12",
+         "timeSegment" : "2017-09-26T13:25:00",
+         "capacity" : 26,
+         "category" : 2,
+         "text" : "> 10"
+      }
+   }, {
+      "space" : {
+         "id" : 100040,
+         "title" : "Braunschweig Hbf P1 Braunschweig Hbf P1 Parkplatz Nord",
+         "station" : {
+            "id" : 835,
+            "name" : "Braunschweig Hbf"
+         },
+         "label" : "P1",
+         "name" : "Parkplatz Hauptbahnhof Nord",
+         "nameDisplay" : "Braunschweig Hbf P1 Parkplatz Nord"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:24:00",
+         "timeSegment" : "2017-09-26T13:20:00",
+         "capacity" : 158,
+         "category" : 3,
+         "text" : "> 30"
+      }
+   }, {
+      "space" : {
+         "id" : 100043,
+         "title" : "Bremen Hbf P1 Bremen Hbf P1 Hochgarage am Bahnhof",
+         "station" : {
+            "id" : 855,
+            "name" : "Bremen Hbf"
+         },
+         "label" : "P1",
+         "name" : "Hochgarage am Bahnhof",
+         "nameDisplay" : "Bremen Hbf P1 Hochgarage am Bahnhof"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:24:58",
+         "timeSegment" : "2017-09-26T13:20:00",
+         "capacity" : 250,
+         "category" : 4,
+         "text" : "> 50"
+      }
+   }, {
+      "space" : {
+         "id" : 100170,
+         "title" : "Kassel-Wilhelmshöhe P2 Kassel Wilhelmshöhe P2 Parkdeck",
+         "station" : {
+            "id" : 3127,
+            "name" : "Kassel-Wilhelmshöhe"
+         },
+         "label" : "P2",
+         "name" : "Parkdeck Bahnhof Kassel-Wilhelmshöhe",
+         "nameDisplay" : "Kassel Wilhelmshöhe P2 Parkdeck"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:25:12",
+         "timeSegment" : "2017-09-26T13:25:00",
+         "capacity" : 340,
+         "category" : 1,
+         "text" : "bis 10"
+      }
+   }, {
+      "space" : {
+         "id" : 100111,
+         "title" : "Gießen P1 Gießen P1 Parkhaus am Bahnhof",
+         "station" : {
+            "id" : 2120,
+            "name" : "Gießen"
+         },
+         "label" : "P1",
+         "name" : "Parkhaus am Bahnhof",
+         "nameDisplay" : "Gießen P1 Parkhaus am Bahnhof"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:22:00",
+         "timeSegment" : "2017-09-26T13:20:00",
+         "capacity" : 245,
+         "category" : 4,
+         "text" : "> 50"
+      }
+   }, {
+      "space" : {
+         "id" : 100240,
+         "title" : "Passau Hbf P4 Passau Hbf P4 Parkhaus Donaupassage",
+         "station" : {
+            "id" : 4872,
+            "name" : "Passau Hbf"
+         },
+         "label" : "P4",
+         "name" : "Parkhaus Donaupassage",
+         "nameDisplay" : "Passau Hbf P4 Parkhaus Donaupassage"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:24:00",
+         "timeSegment" : "2017-09-26T13:20:00",
+         "capacity" : 384,
+         "category" : 4,
+         "text" : "> 50"
+      }
+   }, {
+      "space" : {
+         "id" : 100115,
+         "title" : "Hamburg Hbf P1 Hamburg Hbf P1 Parkhaus Hbf Centrum Hühnerposten",
+         "station" : {
+            "id" : 2514,
+            "name" : "Hamburg Hbf"
+         },
+         "label" : "P1",
+         "name" : "Parkhaus Hauptbahnhof Centrum Hühnerposten",
+         "nameDisplay" : "Hamburg Hbf P1 Parkhaus Hbf Centrum Hühnerposten"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:25:07",
+         "timeSegment" : "2017-09-26T13:25:00",
+         "capacity" : 352,
+         "category" : 2,
+         "text" : "> 10"
+      }
+   }, {
+      "space" : {
+         "id" : 100114,
+         "title" : "Halle (Saale) Hbf P3 Halle Hbf P3 Tiefgarage Charlottencenter",
+         "station" : {
+            "id" : 2498,
+            "name" : "Halle (Saale) Hbf"
+         },
+         "label" : "P3",
+         "name" : "Tiefgarage Charlottencenter",
+         "nameDisplay" : "Halle Hbf P3 Tiefgarage Charlottencenter"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:23:00",
+         "timeSegment" : "2017-09-26T13:20:00",
+         "capacity" : 380,
+         "category" : 4,
+         "text" : "> 50"
+      }
+   }, {
+      "space" : {
+         "id" : 100309,
+         "title" : "Wolfsburg Hbf P2 Wolfsburg Hbf P2 Tiefgarage Hbf / Kino",
+         "station" : {
+            "id" : 6859,
+            "name" : "Wolfsburg Hbf"
+         },
+         "label" : "P2",
+         "name" : "Tiefgarage Hauptbahnhof / Kino",
+         "nameDisplay" : "Wolfsburg Hbf P2 Tiefgarage Hbf / Kino"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:22:00",
+         "timeSegment" : "2017-09-26T13:20:00",
+         "capacity" : 67,
+         "category" : 2,
+         "text" : "> 10"
+      }
+   }, {
+      "space" : {
+         "id" : 100308,
+         "title" : "Wolfsburg Hbf P1 Wolfsburg Hbf P1 Parkdeck",
+         "station" : {
+            "id" : 6859,
+            "name" : "Wolfsburg Hbf"
+         },
+         "label" : "P1",
+         "name" : "Parkdeck Wolfsburg Hauptbahnhof",
+         "nameDisplay" : "Wolfsburg Hbf P1 Parkdeck"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:21:00",
+         "timeSegment" : "2017-09-26T13:20:00",
+         "capacity" : 100,
+         "category" : 1,
+         "text" : "bis 10"
+      }
+   }, {
+      "space" : {
+         "id" : 100054,
+         "title" : "Düren P1 Düren P1 Parkplatz Ludwig-Erhardt-Platz",
+         "station" : {
+            "id" : 1392,
+            "name" : "Düren"
+         },
+         "label" : "P1",
+         "name" : "Ludwig-Erhard-Platz",
+         "nameDisplay" : "Düren P1 Parkplatz Ludwig-Erhardt-Platz"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:24:59",
+         "timeSegment" : "2017-09-26T13:20:00",
+         "capacity" : 191,
+         "category" : 4,
+         "text" : "> 50"
+      }
+   }, {
+      "space" : {
+         "id" : 100058,
+         "title" : "Düsseldorf Hbf P3 Düsseldorf Hbf P3 Parkhaus",
+         "station" : {
+            "id" : 1401,
+            "name" : "Düsseldorf Hbf"
+         },
+         "label" : "P3",
+         "name" : "Parkhaus Düsseldorf Hauptbahnhof",
+         "nameDisplay" : "Düsseldorf Hbf P3 Parkhaus"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:21:00",
+         "timeSegment" : "2017-09-26T13:20:00",
+         "capacity" : 1085,
+         "category" : 4,
+         "text" : "> 50"
+      }
+   }, {
+      "space" : {
+         "id" : 100252,
+         "title" : "Regensburg Hbf P5 Regensburg Hbf P5 Tiefgarage Hbf / Castra Regina Center",
+         "station" : {
+            "id" : 5169,
+            "name" : "Regensburg Hbf"
+         },
+         "label" : "P5",
+         "name" : "Tiefgarage Hauptbahnhof / Castra Regina Center",
+         "nameDisplay" : "Regensburg Hbf P5 Tiefgarage Hbf / Castra Regina Center"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:22:00",
+         "timeSegment" : "2017-09-26T13:20:00",
+         "capacity" : 278,
+         "category" : 4,
+         "text" : "> 50"
+      }
+   }, {
+      "space" : {
+         "id" : 100066,
+         "title" : "Duisburg Hbf P2 Duisburg Hbf P2 Parkhaus",
+         "station" : {
+            "id" : 1374,
+            "name" : "Duisburg Hbf"
+         },
+         "label" : "P2",
+         "name" : "Parkhaus Duisburg Hauptbahnhof",
+         "nameDisplay" : "Duisburg Hbf P2 Parkhaus"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:20:00",
+         "timeSegment" : "2017-09-26T13:20:00",
+         "capacity" : 200,
+         "category" : 1,
+         "text" : "bis 10"
+      }
+   }, {
+      "space" : {
+         "id" : 100130,
+         "title" : "Hannover Hbf P7 Hannover Hbf P7 Tiefgarage Augustenstraße",
+         "station" : {
+            "id" : 2545,
+            "name" : "Hannover Hbf"
+         },
+         "label" : "P7",
+         "name" : "Tiefgarage Hauptbahnhof Augustenstraße",
+         "nameDisplay" : "Hannover Hbf P7 Tiefgarage Augustenstraße"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:21:00",
+         "timeSegment" : "2017-09-26T13:20:00",
+         "capacity" : 138,
+         "category" : 2,
+         "text" : "> 10"
+      }
+   }, {
+      "space" : {
+         "id" : 100197,
+         "title" : "Magdeburg Hbf P2 Magdeburg Hbf P2 City Carré ",
+         "station" : {
+            "id" : 3881,
+            "name" : "Magdeburg Hbf"
+         },
+         "label" : "P2",
+         "name" : "City Carré / Hbf - Tiefpreisparken",
+         "nameDisplay" : "Magdeburg Hbf P2 City Carré "
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:22:00",
+         "timeSegment" : "2017-09-26T13:20:00",
+         "capacity" : 554,
+         "category" : 4,
+         "text" : "> 50"
+      }
+   }, {
+      "space" : {
+         "id" : 100196,
+         "title" : "Magdeburg Hbf P1 Magdeburg Hbf P1 Parkgarage City Carré",
+         "station" : {
+            "id" : 3881,
+            "name" : "Magdeburg Hbf"
+         },
+         "label" : "P1",
+         "name" : "Parkgarage City Carré / Hauptbahnhof",
+         "nameDisplay" : "Magdeburg Hbf P1 Parkgarage City Carré"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:22:00",
+         "timeSegment" : "2017-09-26T13:20:00",
+         "capacity" : 220,
+         "category" : 4,
+         "text" : "> 50"
+      }
+   }, {
+      "space" : {
+         "id" : 100006,
+         "title" : "Aschaffenburg Hbf P1 Aschaffenburg Hbf P1 Parkhaus",
+         "station" : {
+            "id" : 187,
+            "name" : "Aschaffenburg Hbf"
+         },
+         "label" : "P1",
+         "name" : "Parkhaus Aschaffenburg Hauptbahnhof",
+         "nameDisplay" : "Aschaffenburg Hbf P1 Parkhaus"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:25:47",
+         "timeSegment" : "2017-09-26T13:25:00",
+         "capacity" : 400,
+         "category" : 4,
+         "text" : "> 50"
+      }
+   }, {
+      "space" : {
+         "id" : 100134,
+         "title" : "Heilbronn Hbf P1 Heilbronn Hbf P1 Parkplatz",
+         "station" : {
+            "id" : 2648,
+            "name" : "Heilbronn Hbf"
+         },
+         "label" : "P1",
+         "name" : "Parkplatz Heilbronn Hauptbahnhof",
+         "nameDisplay" : "Heilbronn Hbf P1 Parkplatz"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:26:00",
+         "timeSegment" : "2017-09-26T13:25:00",
+         "capacity" : 165,
+         "category" : 4,
+         "text" : "> 50"
+      }
+   }, {
+      "space" : {
+         "id" : 100073,
+         "title" : "Essen Hbf P1 Essen Hbf P1 Parkhaus",
+         "station" : {
+            "id" : 1690,
+            "name" : "Essen Hbf"
+         },
+         "label" : "P1",
+         "name" : "Parkhaus Essen Hauptbahnhof",
+         "nameDisplay" : "Essen Hbf P1 Parkhaus"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:24:00",
+         "timeSegment" : "2017-09-26T13:20:00",
+         "capacity" : 395,
+         "category" : 4,
+         "text" : "> 50"
+      }
+   }, {
+      "space" : {
+         "id" : 100201,
+         "title" : "Mainz Hbf P3 Mainz Hbf P3 Tiefgarage Bonifazius-Türme UG -1",
+         "station" : {
+            "id" : 3898,
+            "name" : "Mainz Hbf"
+         },
+         "label" : "P3",
+         "name" : "Tiefgarage Bonifazius-Türme UG -1",
+         "nameDisplay" : "Mainz Hbf P3 Tiefgarage Bonifazius-Türme UG -1"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:18:00",
+         "timeSegment" : "2017-09-26T13:15:00",
+         "capacity" : 25
+      }
+   }, {
+      "space" : {
+         "id" : 100202,
+         "title" : "Mainz Hbf P4 Mainz Hbf P4 Tiefgarage Bonifazius-Türme UG -2",
+         "station" : {
+            "id" : 3898,
+            "name" : "Mainz Hbf"
+         },
+         "label" : "P4",
+         "name" : "Tiefgarage Bonifazius-Türme UG -2",
+         "nameDisplay" : "Mainz Hbf P4 Tiefgarage Bonifazius-Türme UG -2"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:18:00",
+         "timeSegment" : "2017-09-26T13:15:00",
+         "capacity" : 176,
+         "category" : 4,
+         "text" : "> 50"
+      }
+   }, {
+      "space" : {
+         "id" : 100081,
+         "title" : "Frankfurt (Main) Hbf P1 Frankfurt (Main) Hbf P1 Tiefgarage Hbf Nord",
+         "station" : {
+            "id" : 1866,
+            "name" : "Frankfurt (Main) Hbf"
+         },
+         "label" : "P1",
+         "name" : "Tiefgarage Hauptbahnhof Nord",
+         "nameDisplay" : "Frankfurt (Main) Hbf P1 Tiefgarage Hbf Nord"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:23:00",
+         "timeSegment" : "2017-09-26T13:20:00",
+         "capacity" : 350,
+         "category" : 2,
+         "text" : "> 10"
+      }
+   }, {
+      "space" : {
+         "id" : 100083,
+         "title" : "Frankfurt (Main) Hbf P3 Frankfurt (Main) Hbf P3 Vorfahrt II",
+         "station" : {
+            "id" : 1866,
+            "name" : "Frankfurt (Main) Hbf"
+         },
+         "label" : "P3",
+         "name" : "Hauptbahnhof Vorfahrt II",
+         "nameDisplay" : "Frankfurt (Main) Hbf P3 Vorfahrt II"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:21:00",
+         "timeSegment" : "2017-09-26T13:20:00",
+         "capacity" : 17,
+         "category" : 2,
+         "text" : "> 10"
+      }
+   }, {
+      "space" : {
+         "id" : 100275,
+         "title" : "Stuttgart Hbf P1 Stuttgart Hbf P1 Tiefgarage LBBW",
+         "station" : {
+            "id" : 6071,
+            "name" : "Stuttgart Hbf"
+         },
+         "label" : "P1",
+         "name" : "Tiefgarage LBBW",
+         "nameDisplay" : "Stuttgart Hbf P1 Tiefgarage LBBW"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:21:00",
+         "timeSegment" : "2017-09-26T13:20:00",
+         "capacity" : 745,
+         "category" : 4,
+         "text" : "> 50"
+      }
+   }, {
+      "space" : {
+         "id" : 100082,
+         "title" : "Frankfurt (Main) Hbf P2 Frankfurt (Main) Hbf P2 Vorfahrt I",
+         "station" : {
+            "id" : 1866,
+            "name" : "Frankfurt (Main) Hbf"
+         },
+         "label" : "P2",
+         "name" : "Hauptbahnhof Vorfahrt I",
+         "nameDisplay" : "Frankfurt (Main) Hbf P2 Vorfahrt I"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:21:00",
+         "timeSegment" : "2017-09-26T13:20:00",
+         "capacity" : 47,
+         "category" : 1,
+         "text" : "bis 10"
+      }
+   }, {
+      "space" : {
+         "id" : 100210,
+         "title" : "München Hbf P1 München Hbf P1 Vorplatz Bayerstraße",
+         "station" : {
+            "id" : 4234,
+            "name" : "München Hbf"
+         },
+         "label" : "P1",
+         "name" : "Parkplatz Bayerstraße",
+         "nameDisplay" : "München Hbf P1 Vorplatz Bayerstraße"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:25:35",
+         "timeSegment" : "2017-09-26T13:25:00",
+         "capacity" : 28,
+         "category" : 1,
+         "text" : "bis 10"
+      }
+   }, {
+      "space" : {
+         "id" : 100213,
+         "title" : "München Hbf P4 München Hbf P4 Tiefgarage Hbf Süd",
+         "station" : {
+            "id" : 4234,
+            "name" : "München Hbf"
+         },
+         "label" : "P4",
+         "name" : "Tiefgarage München Hauptbahnhof Süd",
+         "nameDisplay" : "München Hbf P4 Tiefgarage Hbf Süd"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:16:00",
+         "timeSegment" : "2017-09-26T13:15:00",
+         "capacity" : 200,
+         "category" : 4,
+         "text" : "> 50"
+      }
+   }, {
+      "space" : {
+         "id" : 100023,
+         "title" : "Berlin Ostbahnhof P1 Berlin Ostbahnhof P1 Parkplatz",
+         "station" : {
+            "id" : 530,
+            "name" : "Berlin Ostbahnhof"
+         },
+         "label" : "P1",
+         "name" : "Parkplatz Berlin Ostbahnhof",
+         "nameDisplay" : "Berlin Ostbahnhof P1 Parkplatz"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:25:00",
+         "timeSegment" : "2017-09-26T13:25:00",
+         "capacity" : 89,
+         "category" : 3,
+         "text" : "> 30"
+      }
+   }, {
+      "space" : {
+         "id" : 100279,
+         "title" : "Stuttgart-Bad Cannstatt P2 Stuttgart-Bad Cannstatt P2 Parkhaus Wilhelmsplatz Ebenen -1 bis 6",
+         "station" : {
+            "id" : 6077,
+            "name" : "Stuttgart-Bad Cannstatt"
+         },
+         "label" : "P2",
+         "name" : "Ebenen -1 bis 6",
+         "nameDisplay" : "Stuttgart-Bad Cannstatt P2 Parkhaus Wilhelmsplatz Ebenen -1 bis 6"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:24:00",
+         "timeSegment" : "2017-09-26T13:20:00",
+         "capacity" : 125,
+         "category" : 4,
+         "text" : "> 50"
+      }
+   }, {
+      "space" : {
+         "id" : 100278,
+         "title" : "Stuttgart-Bad Cannstatt P1 Stuttgart-Bad Cannstatt P1 Parkhaus Wilhelmsplatz Ebenen 7 bis 12",
+         "station" : {
+            "id" : 6077,
+            "name" : "Stuttgart-Bad Cannstatt"
+         },
+         "label" : "P1",
+         "name" : "Parkhaus Wilhelmsplatz Ebenen 7 bis 12",
+         "nameDisplay" : "Stuttgart-Bad Cannstatt P1 Parkhaus Wilhelmsplatz Ebenen 7 bis 12"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:24:00",
+         "timeSegment" : "2017-09-26T13:20:00",
+         "capacity" : 129,
+         "category" : 4,
+         "text" : "> 50"
+      }
+   }, {
+      "space" : {
+         "id" : 100025,
+         "title" : "Berlin Südkreuz P1 Berlin Südkreuz P1 Parkdeck",
+         "station" : {
+            "id" : 4859,
+            "name" : "Berlin Südkreuz"
+         },
+         "label" : "P1",
+         "name" : "Parkhaus Bahnhof Berlin Südkreuz",
+         "nameDisplay" : "Berlin Südkreuz P1 Parkdeck"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:19:00",
+         "timeSegment" : "2017-09-26T13:15:00",
+         "capacity" : 150,
+         "category" : 4,
+         "text" : "> 50"
+      }
+   }, {
+      "space" : {
+         "id" : 100024,
+         "title" : "Berlin Ostbahnhof P2 Berlin Ostbahnhof P2 Tiefgarage",
+         "station" : {
+            "id" : 530,
+            "name" : "Berlin Ostbahnhof"
+         },
+         "label" : "P2",
+         "name" : "Tiefgarage Berlin Ostbahnhof",
+         "nameDisplay" : "Berlin Ostbahnhof P2 Tiefgarage"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:25:00",
+         "timeSegment" : "2017-09-26T13:25:00",
+         "capacity" : 180,
+         "category" : 2,
+         "text" : "> 10"
+      }
+   }, {
+      "space" : {
+         "id" : 100280,
+         "title" : "Stuttgart-Bad Cannstatt P3 Stuttgart-Bad Cannstatt P3 Parkhaus Wilhelmsplatz Ebenen -3 und -2",
+         "station" : {
+            "id" : 6077,
+            "name" : "Stuttgart-Bad Cannstatt"
+         },
+         "label" : "P3",
+         "name" : "Ebenen -3 und -2",
+         "nameDisplay" : "Stuttgart-Bad Cannstatt P3 Parkhaus Wilhelmsplatz Ebenen -3 und -2"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:24:00",
+         "timeSegment" : "2017-09-26T13:20:00",
+         "capacity" : 38,
+         "category" : 2,
+         "text" : "> 10"
+      }
+   }, {
+      "space" : {
+         "id" : 100090,
+         "title" : "Freiburg (Breisgau) Hbf P1 Freiburg (Breisgau) Hbf P1 Tiefgarage am Bahnhof",
+         "station" : {
+            "id" : 1893,
+            "name" : "Freiburg (Breisgau) Hbf"
+         },
+         "label" : "P1",
+         "name" : "Tiefgarage am Bahnhof",
+         "nameDisplay" : "Freiburg (Breisgau) Hbf P1 Tiefgarage am Bahnhof"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:18:00",
+         "timeSegment" : "2017-09-26T13:15:00",
+         "capacity" : 138,
+         "category" : 4,
+         "text" : "> 50"
+      }
+   }, {
+      "space" : {
+         "id" : 100031,
+         "title" : "Bietigheim-Bissingen P1 Bietigheim-Bissingen P1 Parkhaus Süd",
+         "station" : {
+            "id" : 636,
+            "name" : "Bietigheim-Bissingen"
+         },
+         "label" : "P1",
+         "name" : "Parkhaus Stuttgarter Straße Süd",
+         "nameDisplay" : "Bietigheim-Bissingen P1 Parkhaus Süd"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:25:14",
+         "timeSegment" : "2017-09-26T13:25:00",
+         "capacity" : 291,
+         "category" : 4,
+         "text" : "> 50"
+      }
+   }, {
+      "space" : {
+         "id" : 100158,
+         "title" : "Kaiserslautern Hbf P2 Kaiserslautern Hbf P2 Park+Ride-Parkhaus",
+         "station" : {
+            "id" : 3082,
+            "name" : "Kaiserslautern Hbf"
+         },
+         "label" : "P2",
+         "name" : "Park+Ride-Parkhaus Hauptbahnhof",
+         "nameDisplay" : "Kaiserslautern Hbf P2 Park+Ride-Parkhaus"
+      },
+      "allocation" : {
+         "validData" : true,
+         "timestamp" : "2017-09-26T13:24:00",
+         "timeSegment" : "2017-09-26T13:20:00",
+         "capacity" : 179,
+         "category" : 4,
+         "text" : "> 50"
+      }
+   } ]
+}

--- a/spec/data/bahnpark/spaces-26.09.2017.json
+++ b/spec/data/bahnpark/spaces-26.09.2017.json
@@ -1,0 +1,28054 @@
+{
+   "type" : "items",
+   "offset" : 0,
+   "limit" : 300,
+   "count" : 292,
+   "totalCount" : 292,
+   "items" : [ {
+      "type" : "space",
+      "id" : 100001,
+      "title" : "Aalen P2 Parkplatz Bahnhof Aalen Rückseite",
+      "station" : {
+         "id" : 4,
+         "name" : "Aalen"
+      },
+      "label" : "P2",
+      "spaceNumber" : "1",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Aalen Rückseite",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 10.097189,
+         "latitude" : 48.839307
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000002.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Aalen",
+         "postalCode" : "73431",
+         "street" : "Hirschbachstraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "55",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 218442,
+         "duration" : "20min"
+      }, {
+         "id" : 218443,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 218444,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 218445,
+         "duration" : "1day",
+         "price" : 3.5
+      }, {
+         "id" : 218446,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218447,
+         "duration" : "1week",
+         "price" : 14.0
+      }, {
+         "id" : 218448,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218449,
+         "duration" : "1monthVendingMachine",
+         "price" : 30.0
+      }, {
+         "id" : 218450,
+         "duration" : "1monthLongTerm",
+         "price" : 30.0
+      }, {
+         "id" : 218451,
+         "duration" : "1monthReservation",
+         "price" : 50.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100002,
+      "title" : "Amberg P1 Parkplatz Bahnhof Amberg",
+      "station" : {
+         "id" : 134,
+         "name" : "Amberg"
+      },
+      "label" : "P1",
+      "spaceNumber" : "383",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Amberg",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 11.863333,
+         "latitude" : 49.446586
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000566.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Amberg",
+         "postalCode" : "92224",
+         "street" : "Kaiser-Ludwig-Ring"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "51",
+      "numberHandicapedPlaces" : "2",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Woche",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 218452,
+         "duration" : "20min"
+      }, {
+         "id" : 218453,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 218454,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 218455,
+         "duration" : "1day",
+         "price" : 4.5
+      }, {
+         "id" : 218456,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218457,
+         "duration" : "1week",
+         "price" : 18.0
+      }, {
+         "id" : 218458,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218459,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 218460,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 218461,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100003,
+      "title" : "Ansbach P1 Parkplatz Bahnhof Ansbach Empfangsgeb.",
+      "station" : {
+         "id" : 161,
+         "name" : "Ansbach"
+      },
+      "label" : "P1",
+      "spaceNumber" : "3",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Ansbach Empfangsgeb.",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 10.57871,
+         "latitude" : 49.298654
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000009.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Ansbach",
+         "postalCode" : "91522",
+         "street" : "Bahnhofsplatz 2",
+         "supplement" : "Rückseite des Bahnhofsgebäudes",
+         "supplementEn" : "back of the station building"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "42",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "400",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 218462,
+         "duration" : "20min"
+      }, {
+         "id" : 218463,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 218464,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 218465,
+         "duration" : "1day",
+         "price" : 4.4
+      }, {
+         "id" : 218466,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218467,
+         "duration" : "1week",
+         "price" : 17.6
+      }, {
+         "id" : 218468,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218469,
+         "duration" : "1monthVendingMachine",
+         "price" : 37.0
+      }, {
+         "id" : 218470,
+         "duration" : "1monthLongTerm",
+         "price" : 37.0
+      }, {
+         "id" : 218471,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100004,
+      "title" : "Ansbach P2 Bahnhof Ansbach Turnitzstraße am Gleis",
+      "station" : {
+         "id" : 161,
+         "name" : "Ansbach"
+      },
+      "label" : "P2",
+      "spaceNumber" : "4",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Bahnhof Ansbach Turnitzstraße am Gleis",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 10.576573,
+         "latitude" : 49.298149
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000009.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Ansbach",
+         "postalCode" : "91522",
+         "street" : "Bahnhofsplatz/Turnitzstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "30",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "400",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 218472,
+         "duration" : "20min"
+      }, {
+         "id" : 218473,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 218474,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 218475,
+         "duration" : "1day",
+         "price" : 4.0
+      }, {
+         "id" : 218476,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218477,
+         "duration" : "1week",
+         "price" : 16.0
+      }, {
+         "id" : 218478,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218479,
+         "duration" : "1monthVendingMachine",
+         "price" : 37.0
+      }, {
+         "id" : 218480,
+         "duration" : "1monthLongTerm",
+         "price" : 37.0
+      }, {
+         "id" : 218481,
+         "duration" : "1monthReservation",
+         "price" : 50.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100005,
+      "title" : "Ansbach P3 Parkplatz Bahnhof Ansbach Turnitzstraße",
+      "station" : {
+         "id" : 161,
+         "name" : "Ansbach"
+      },
+      "label" : "P3",
+      "spaceNumber" : "2",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Ansbach Turnitzstraße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 10.57459,
+         "latitude" : 49.298395
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000009.pdf",
+      "operator" : "Contipark Parkgaragen-Gesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Ansbach",
+         "postalCode" : "91522",
+         "street" : "Turnitzstraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "59",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "450",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 761023,
+         "duration" : "20min"
+      }, {
+         "id" : 761024,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 761025,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 761026,
+         "duration" : "1day",
+         "price" : 4.0
+      }, {
+         "id" : 761027,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 761028,
+         "duration" : "1week",
+         "price" : 16.0
+      }, {
+         "id" : 761029,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 761030,
+         "duration" : "1monthVendingMachine",
+         "price" : 35.0
+      }, {
+         "id" : 761031,
+         "duration" : "1monthLongTerm",
+         "price" : 35.0
+      }, {
+         "id" : 761032,
+         "duration" : "1monthReservation",
+         "price" : 50.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100006,
+      "title" : "Aschaffenburg Hbf P1 Aschaffenburg Hbf P1 Parkhaus",
+      "station" : {
+         "id" : 187,
+         "name" : "Aschaffenburg Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "350",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkhaus Aschaffenburg Hauptbahnhof",
+      "nameDisplay" : "Aschaffenburg Hbf P1 Parkhaus",
+      "spaceType" : "Parkhaus",
+      "spaceTypeEn" : "Multi storey car park",
+      "spaceTypeName" : "Parkhaus",
+      "geoLocation" : {
+         "longitude" : 9.143642,
+         "latitude" : 49.979847
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000010.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Aschaffenburg",
+         "postalCode" : "63739",
+         "street" : "Ludwigstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "459",
+      "numberHandicapedPlaces" : "5",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "250",
+         "clearanceHeight" : "229.99999999999997",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : true,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffDiscount" : "Rabattierung mit BahnCard direkt am Kassenautomaten.",
+         "tariffFreeParkingTime" : "20 Min.",
+         "tariffSpecialEn" : "Season ticket for residents (Mon-Fri: 5:00pm - 09:00am; Sat, Sun: all day): 35.00.",
+         "tariffSpecial" : "Dauerparken für Anwohner (Mo-Fr: 17:00 - 09:00 Uhr; Sa, So: ganztägig): 35,00 pro Monat.",
+         "tariffDiscountEn" : "BahnCard discount available directly at the pay station.",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA), EC-Karte",
+         "tariffFreeParkingTimeEn" : "20 mins.",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA), EC-Card"
+      },
+      "tariffPrices" : [ {
+         "id" : 218492,
+         "duration" : "20min"
+      }, {
+         "id" : 218493,
+         "duration" : "30min"
+      }, {
+         "id" : 218494,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 218495,
+         "duration" : "1day",
+         "price" : 10.0
+      }, {
+         "id" : 218496,
+         "duration" : "1dayDiscount",
+         "price" : 8.5
+      }, {
+         "id" : 218497,
+         "duration" : "1week"
+      }, {
+         "id" : 218498,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218499,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 218500,
+         "duration" : "1monthLongTerm",
+         "price" : 75.0
+      }, {
+         "id" : 218501,
+         "duration" : "1monthReservation",
+         "price" : 120.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100007,
+      "title" : "Aschaffenburg Hbf P3 Parkplatz Aschaffenburg Kolbornstraße",
+      "station" : {
+         "id" : 187,
+         "name" : "Aschaffenburg Hbf"
+      },
+      "label" : "P3",
+      "spaceNumber" : "8",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Kolbornstraße",
+      "nameDisplay" : "Parkplatz Aschaffenburg Kolbornstraße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.151899,
+         "latitude" : 49.980491
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000010.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Aschaffenburg",
+         "postalCode" : "63739",
+         "street" : "Kolbornstraße"
+      },
+      "distance" : "ca. 500",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "33",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "250",
+         "clearanceHeight" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 10 days from the parking ticket machine",
+         "tariffSpecialEn" : "Up to 4 hours: 3.00",
+         "tariffSpecial" : "Bis 4 Stunden: 3,00",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 10 Tage am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 737686,
+         "duration" : "20min"
+      }, {
+         "id" : 737687,
+         "duration" : "30min"
+      }, {
+         "id" : 737688,
+         "duration" : "1hour"
+      }, {
+         "id" : 737689,
+         "duration" : "1day",
+         "price" : 4.0
+      }, {
+         "id" : 737690,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 737691,
+         "duration" : "1week",
+         "price" : 28.0
+      }, {
+         "id" : 737692,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 737693,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 737694,
+         "duration" : "1monthLongTerm",
+         "price" : 50.0
+      }, {
+         "id" : 737695,
+         "duration" : "1monthReservation",
+         "price" : 75.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100009,
+      "title" : "Aulendorf P1 Parkplatz Bahnhof Aulendorf",
+      "station" : {
+         "id" : 226,
+         "name" : "Aulendorf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "12",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Aulendorf",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.64376,
+         "latitude" : 47.953787
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000014.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Aulendorf",
+         "postalCode" : "88326",
+         "street" : "Waldseer Straße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "42",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Woche oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 218512,
+         "duration" : "20min"
+      }, {
+         "id" : 218513,
+         "duration" : "30min",
+         "price" : 0.5
+      }, {
+         "id" : 218514,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 218515,
+         "duration" : "1day",
+         "price" : 2.5
+      }, {
+         "id" : 218516,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218517,
+         "duration" : "1week",
+         "price" : 10.0
+      }, {
+         "id" : 218518,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218519,
+         "duration" : "1monthVendingMachine",
+         "price" : 12.0
+      }, {
+         "id" : 218520,
+         "duration" : "1monthLongTerm",
+         "price" : 12.0
+      }, {
+         "id" : 218521,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100011,
+      "title" : "Bad Hersfeld P1 Parkplatz Bad Hersfeld Bahnhofsplatz",
+      "station" : {
+         "id" : 282,
+         "name" : "Bad Hersfeld"
+      },
+      "label" : "P1",
+      "spaceNumber" : "413",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bad Hersfeld Bahnhofsplatz",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.716196,
+         "latitude" : 50.870441
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000020.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Bad Hersfeld",
+         "postalCode" : "36251",
+         "street" : "Bahnhofsplatz"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "41",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceHeight" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 761043,
+         "duration" : "20min"
+      }, {
+         "id" : 761044,
+         "duration" : "30min",
+         "price" : 0.5
+      }, {
+         "id" : 761045,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 761046,
+         "duration" : "1day",
+         "price" : 2.5
+      }, {
+         "id" : 761047,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 761048,
+         "duration" : "1week",
+         "price" : 10.0
+      }, {
+         "id" : 761049,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 761050,
+         "duration" : "1monthVendingMachine",
+         "price" : 35.0
+      }, {
+         "id" : 761051,
+         "duration" : "1monthLongTerm",
+         "price" : 35.0
+      }, {
+         "id" : 761052,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100012,
+      "title" : "Bad Kreuznach P1 Vorfahrt Bahnhof Bad Kreuznach",
+      "station" : {
+         "id" : 296,
+         "name" : "Bad Kreuznach"
+      },
+      "label" : "P1",
+      "spaceNumber" : "14",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Vorfahrt Bahnhof Bad Kreuznach",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 7.865589,
+         "latitude" : 49.842331
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000021.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Bad Kreuznach",
+         "postalCode" : "55543",
+         "street" : "Europaplatz"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "16",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "600",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 day",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Tag",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 218532,
+         "duration" : "20min"
+      }, {
+         "id" : 218533,
+         "duration" : "30min"
+      }, {
+         "id" : 218534,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 218535,
+         "duration" : "1day",
+         "price" : 6.0
+      }, {
+         "id" : 218536,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218537,
+         "duration" : "1week"
+      }, {
+         "id" : 218538,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218539,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 218540,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 218541,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100013,
+      "title" : "Bad Kreuznach P2 Parkplatz Bahnhof Bad Kreuznach",
+      "station" : {
+         "id" : 296,
+         "name" : "Bad Kreuznach"
+      },
+      "label" : "P2",
+      "spaceNumber" : "15",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Bad Kreuznach",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 7.865287,
+         "latitude" : 49.84152
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000021.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Bad Kreuznach",
+         "postalCode" : "55543",
+         "street" : "Europaplatz"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "54",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "400",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week from the parking ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Woche am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 218542,
+         "duration" : "20min"
+      }, {
+         "id" : 218543,
+         "duration" : "30min"
+      }, {
+         "id" : 218544,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 218545,
+         "duration" : "1day",
+         "price" : 4.5
+      }, {
+         "id" : 218546,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218547,
+         "duration" : "1week",
+         "price" : 22.5
+      }, {
+         "id" : 218548,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218549,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 218550,
+         "duration" : "1monthLongTerm",
+         "price" : 40.0
+      }, {
+         "id" : 218551,
+         "duration" : "1monthReservation",
+         "price" : 60.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100014,
+      "title" : "Bad Oldesloe P1 Bahnhof Bad Oldesloe zwischen d. Gleisen",
+      "station" : {
+         "id" : 317,
+         "name" : "Bad Oldesloe"
+      },
+      "label" : "P1",
+      "spaceNumber" : "16",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Bahnhof Bad Oldesloe zwischen d. Gleisen",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 10.382825,
+         "latitude" : 53.805962
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000023.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Bad Oldesloe",
+         "postalCode" : "23843",
+         "street" : "Mommsenstraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "28",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 218552,
+         "duration" : "20min"
+      }, {
+         "id" : 218553,
+         "duration" : "30min",
+         "price" : 0.5
+      }, {
+         "id" : 218554,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 218555,
+         "duration" : "1day",
+         "price" : 2.6
+      }, {
+         "id" : 218556,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218557,
+         "duration" : "1week",
+         "price" : 18.2
+      }, {
+         "id" : 218558,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218559,
+         "duration" : "1monthVendingMachine",
+         "price" : 40.0
+      }, {
+         "id" : 218560,
+         "duration" : "1monthLongTerm",
+         "price" : 40.0
+      }, {
+         "id" : 218561,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100015,
+      "title" : "Bad Oldesloe P2 Bahnhof Bad Oldesloe in Zufahrt",
+      "station" : {
+         "id" : 317,
+         "name" : "Bad Oldesloe"
+      },
+      "label" : "P2",
+      "spaceNumber" : "449",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Bahnhof Bad Oldesloe in Zufahrt",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 10.383452,
+         "latitude" : 53.806651
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000023.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Bad Oldesloe",
+         "postalCode" : "23843",
+         "street" : "Mommsenstraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "14",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 218562,
+         "duration" : "20min"
+      }, {
+         "id" : 218563,
+         "duration" : "30min",
+         "price" : 0.5
+      }, {
+         "id" : 218564,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 218565,
+         "duration" : "1day",
+         "price" : 2.6
+      }, {
+         "id" : 218566,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218567,
+         "duration" : "1week",
+         "price" : 18.2
+      }, {
+         "id" : 218568,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218569,
+         "duration" : "1monthVendingMachine",
+         "price" : 40.0
+      }, {
+         "id" : 218570,
+         "duration" : "1monthLongTerm",
+         "price" : 40.0
+      }, {
+         "id" : 218571,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100016,
+      "title" : "Bamberg P1 Bahnhof Bamberg Vorplatz",
+      "station" : {
+         "id" : 393,
+         "name" : "Bamberg"
+      },
+      "label" : "P1",
+      "spaceNumber" : "19",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Bahnhof Bamberg Vorplatz",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 10.899193,
+         "latitude" : 49.900187
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000025.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Bamberg",
+         "postalCode" : "96052",
+         "street" : "Ludwigstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "42",
+      "numberHandicapedPlaces" : "1",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Woche",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 218572,
+         "duration" : "20min"
+      }, {
+         "id" : 218573,
+         "duration" : "30min",
+         "price" : 1.0
+      }, {
+         "id" : 218574,
+         "duration" : "1hour",
+         "price" : 2.0
+      }, {
+         "id" : 218575,
+         "duration" : "1day",
+         "price" : 6.0
+      }, {
+         "id" : 218576,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218577,
+         "duration" : "1week",
+         "price" : 42.0
+      }, {
+         "id" : 218578,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218579,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 218580,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 218581,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100017,
+      "title" : "Bamberg P2 Parkplatz Bahnhof Bamberg links",
+      "station" : {
+         "id" : 393,
+         "name" : "Bamberg"
+      },
+      "label" : "P2",
+      "spaceNumber" : "18",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Bamberg links",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 10.898195,
+         "latitude" : 49.900974
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000025.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Bamberg",
+         "postalCode" : "96052",
+         "street" : "Ludwigstraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "80",
+      "numberHandicapedPlaces" : "2",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "400",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : true,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffPointOfSale" : "Park&Rail-Karten erhältlich an allen Verkaufsstellen der Deutschen Bahn (außer Internet).",
+         "tariffPointOfSaleEn" : "Park&Rail cards available from all Deutsche Bahn points of sale (except online).  ",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 218582,
+         "duration" : "20min"
+      }, {
+         "id" : 218583,
+         "duration" : "30min",
+         "price" : 1.0
+      }, {
+         "id" : 218584,
+         "duration" : "1hour",
+         "price" : 2.0
+      }, {
+         "id" : 218585,
+         "duration" : "1day",
+         "price" : 5.2
+      }, {
+         "id" : 218586,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218587,
+         "duration" : "1week",
+         "price" : 20.8
+      }, {
+         "id" : 218588,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218589,
+         "duration" : "1monthVendingMachine",
+         "price" : 47.0
+      }, {
+         "id" : 218590,
+         "duration" : "1monthLongTerm",
+         "price" : 47.0
+      }, {
+         "id" : 218591,
+         "duration" : "1monthReservation",
+         "price" : 70.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100018,
+      "title" : "Bayreuth Hbf P1 Bayreuth Hbf Vorfahrt",
+      "station" : {
+         "id" : 439,
+         "name" : "Bayreuth Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "21",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Bayreuth Hbf Vorfahrt",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 11.579322,
+         "latitude" : 49.94969
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000028.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Bayreuth",
+         "postalCode" : "95444",
+         "street" : "Bahnhofstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "15",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 day",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 1 Tag",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 218592,
+         "duration" : "20min"
+      }, {
+         "id" : 218593,
+         "duration" : "30min",
+         "price" : 0.65
+      }, {
+         "id" : 218594,
+         "duration" : "1hour",
+         "price" : 1.3
+      }, {
+         "id" : 218595,
+         "duration" : "1day",
+         "price" : 8.0
+      }, {
+         "id" : 218596,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218597,
+         "duration" : "1week"
+      }, {
+         "id" : 218598,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218599,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 218600,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 218601,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100019,
+      "title" : "Bayreuth Hbf P2 Parkplatz Bayreuth Hbf Bürgerreutherstr.",
+      "station" : {
+         "id" : 439,
+         "name" : "Bayreuth Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "351",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bayreuth Hbf Bürgerreutherstr.",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 11.579347,
+         "latitude" : 49.950426
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000028.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Bayreuth",
+         "postalCode" : "95444",
+         "street" : "Bürgerreutherstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "73",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 10 days or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 10 Tage oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 218602,
+         "duration" : "20min"
+      }, {
+         "id" : 218603,
+         "duration" : "30min",
+         "price" : 0.75
+      }, {
+         "id" : 218604,
+         "duration" : "1hour",
+         "price" : 1.5
+      }, {
+         "id" : 218605,
+         "duration" : "1day",
+         "price" : 6.0
+      }, {
+         "id" : 218606,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218607,
+         "duration" : "1week",
+         "price" : 24.0
+      }, {
+         "id" : 218608,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218609,
+         "duration" : "1monthVendingMachine",
+         "price" : 48.0
+      }, {
+         "id" : 218610,
+         "duration" : "1monthLongTerm",
+         "price" : 48.0
+      }, {
+         "id" : 218611,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100020,
+      "title" : "Bayreuth Hbf P3 Parkplatz Bayreuth Hbf Tunnelstraße",
+      "station" : {
+         "id" : 439,
+         "name" : "Bayreuth Hbf"
+      },
+      "label" : "P3",
+      "spaceNumber" : "23",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bayreuth Hbf Tunnelstraße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 11.581337,
+         "latitude" : 49.949098
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000028.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Bayreuth",
+         "postalCode" : "95444",
+         "street" : "Tunnelstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "29",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 218612,
+         "duration" : "20min"
+      }, {
+         "id" : 218613,
+         "duration" : "30min",
+         "price" : 0.5
+      }, {
+         "id" : 218614,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 218615,
+         "duration" : "1day",
+         "price" : 5.0
+      }, {
+         "id" : 218616,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218617,
+         "duration" : "1week",
+         "price" : 20.0
+      }, {
+         "id" : 218618,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218619,
+         "duration" : "1monthVendingMachine",
+         "price" : 48.0
+      }, {
+         "id" : 218620,
+         "duration" : "1monthLongTerm",
+         "price" : 48.0
+      }, {
+         "id" : 218621,
+         "duration" : "1monthReservation",
+         "price" : 75.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100022,
+      "title" : "Berlin Hauptbahnhof P1 Parkhaus Berlin Hbf",
+      "station" : {
+         "id" : 1071,
+         "name" : "Berlin Hauptbahnhof"
+      },
+      "label" : "P1",
+      "spaceNumber" : "24",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkhaus Berlin Hauptbahnhof",
+      "nameDisplay" : "Parkhaus Berlin Hbf",
+      "spaceType" : "Tiefgarage",
+      "spaceTypeEn" : "Underground car park",
+      "spaceTypeName" : "Tiefgarage",
+      "geoLocation" : {
+         "longitude" : 13.366282,
+         "latitude" : 52.524291
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8098160.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Berlin",
+         "postalCode" : "10557",
+         "street" : "Clara-Jaschke-Straße / B-96-Tunnel",
+         "supplement" : "unterirdisch im B-96-Tunnel; oberirdisch Clara-Jaschke-Straße",
+         "supplementEn" : "underground in the B96 tunnel; overground in Clara-Jaschke-Straße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "860",
+      "numberHandicapedPlaces" : "28",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "250",
+         "clearanceHeight" : "200",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "ja"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : true,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : true,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffDiscount" : "Rabattierung mit BahnCard direkt am Kassenautomaten.",
+         "tariffFreeParkingTime" : "15 Min.",
+         "tariffDiscountEn" : "BahnCard discount available directly at the pay station.",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA), P Card",
+         "tariffPointOfSale" : "Nur mit gültiger bahn.comfort-Karte.",
+         "tariffPointOfSaleEn" : "Only with a valid bahn.comfort card. ",
+         "tariffPaymentCustomerCards" : "P Card",
+         "tariffFreeParkingTimeEn" : "15 mins.",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA), P Card"
+      },
+      "tariffPrices" : [ {
+         "id" : 218622,
+         "duration" : "20min"
+      }, {
+         "id" : 218623,
+         "duration" : "30min"
+      }, {
+         "id" : 218624,
+         "duration" : "1hour",
+         "price" : 2.5
+      }, {
+         "id" : 218625,
+         "duration" : "1day",
+         "price" : 22.0
+      }, {
+         "id" : 218626,
+         "duration" : "1dayDiscount",
+         "price" : 18.0
+      }, {
+         "id" : 218627,
+         "duration" : "1week",
+         "price" : 50.0
+      }, {
+         "id" : 218628,
+         "duration" : "1weekDiscount",
+         "price" : 45.0
+      }, {
+         "id" : 218629,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 218630,
+         "duration" : "1monthLongTerm",
+         "price" : 190.0
+      }, {
+         "id" : 218631,
+         "duration" : "1monthReservation",
+         "price" : 235.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100023,
+      "title" : "Berlin Ostbahnhof P1 Berlin Ostbahnhof P1 Parkplatz",
+      "station" : {
+         "id" : 530,
+         "name" : "Berlin Ostbahnhof"
+      },
+      "label" : "P1",
+      "spaceNumber" : "288",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Berlin Ostbahnhof",
+      "nameDisplay" : "Berlin Ostbahnhof P1 Parkplatz",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 13.434084,
+         "latitude" : 52.509548
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8010255.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Berlin",
+         "postalCode" : "10243",
+         "street" : "Am Ostbahnhof"
+      },
+      "distance" : "<50",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "113",
+      "numberHandicapedPlaces" : "2",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "240",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : true,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffDiscount" : "Rabattierung mit BahnCard direkt am Kassenautomaten.",
+         "tariffFreeParkingTime" : "nein",
+         "tariffSpecialEn" : "Evening tariff: 6pm - 3am: 3.00 max.",
+         "tariffSpecial" : "Nachteulentarif: 18:00 bis 03:00 Uhr: 3,00 max.",
+         "tariffDiscountEn" : "BahnCard discount available directly at the pay station.",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA), P Card",
+         "tariffPaymentCustomerCards" : "P Card",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA), P Card"
+      },
+      "tariffPrices" : [ {
+         "id" : 761033,
+         "duration" : "20min"
+      }, {
+         "id" : 761034,
+         "duration" : "30min"
+      }, {
+         "id" : 761035,
+         "duration" : "1hour",
+         "price" : 1.5
+      }, {
+         "id" : 761036,
+         "duration" : "1day",
+         "price" : 6.5
+      }, {
+         "id" : 761037,
+         "duration" : "1dayDiscount",
+         "price" : 5.0
+      }, {
+         "id" : 761038,
+         "duration" : "1week"
+      }, {
+         "id" : 761039,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 761040,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 761041,
+         "duration" : "1monthLongTerm",
+         "price" : 85.0
+      }, {
+         "id" : 761042,
+         "duration" : "1monthReservation",
+         "price" : 150.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100024,
+      "title" : "Berlin Ostbahnhof P2 Berlin Ostbahnhof P2 Tiefgarage",
+      "station" : {
+         "id" : 530,
+         "name" : "Berlin Ostbahnhof"
+      },
+      "label" : "P2",
+      "spaceNumber" : "289",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Tiefgarage Berlin Ostbahnhof",
+      "nameDisplay" : "Berlin Ostbahnhof P2 Tiefgarage",
+      "spaceType" : "Tiefgarage",
+      "spaceTypeEn" : "Underground car park",
+      "spaceTypeName" : "Tiefgarage",
+      "geoLocation" : {
+         "longitude" : 13.433375,
+         "latitude" : 52.509418
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8010255.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Berlin",
+         "postalCode" : "10243",
+         "street" : "Stralauer Platz/Am Ostbahnhof"
+      },
+      "distance" : "<50",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "230",
+      "numberHandicapedPlaces" : "2",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "270",
+         "clearanceHeight" : "220.00000000000003",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "ja"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : true,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffDiscount" : "Rabattierung mit BahnCard direkt am Kassenautomaten.",
+         "tariffFreeParkingTime" : "nein",
+         "tariffSpecialEn" : "Evening tariff: 6pm - 3am: 3.00 max.",
+         "tariffSpecial" : "Nachteulentarif: 18:00 bis 03:00 Uhr: 3,00 max.",
+         "tariffDiscountEn" : "BahnCard discount available directly at the pay station.",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA), P Card",
+         "tariffPaymentCustomerCards" : "P Card",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA), P Card"
+      },
+      "tariffPrices" : [ {
+         "id" : 227284,
+         "duration" : "20min"
+      }, {
+         "id" : 227285,
+         "duration" : "30min"
+      }, {
+         "id" : 227286,
+         "duration" : "1hour",
+         "price" : 1.5
+      }, {
+         "id" : 227287,
+         "duration" : "1day",
+         "price" : 6.5
+      }, {
+         "id" : 227288,
+         "duration" : "1dayDiscount",
+         "price" : 5.0
+      }, {
+         "id" : 227289,
+         "duration" : "1week"
+      }, {
+         "id" : 227290,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 227291,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 227292,
+         "duration" : "1monthLongTerm",
+         "price" : 85.0
+      }, {
+         "id" : 227293,
+         "duration" : "1monthReservation",
+         "price" : 150.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100025,
+      "title" : "Berlin Südkreuz P1 Berlin Südkreuz P1 Parkdeck",
+      "station" : {
+         "id" : 4859,
+         "name" : "Berlin Südkreuz"
+      },
+      "label" : "P1",
+      "spaceNumber" : "25",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkhaus Bahnhof Berlin Südkreuz",
+      "nameDisplay" : "Berlin Südkreuz P1 Parkdeck",
+      "spaceType" : "Parkdeck",
+      "spaceTypeEn" : "Parking deck",
+      "spaceTypeName" : "Parkhaus",
+      "geoLocation" : {
+         "longitude" : 13.363608,
+         "latitude" : 52.474839
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8011113.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Berlin",
+         "postalCode" : "10829",
+         "street" : "Lotte-Laserstein-Straße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "213",
+      "numberHandicapedPlaces" : "6",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "reservation" : "www.parkplatz.kaufen",
+      "spaceInfo" : {
+         "clearanceWidth" : "295",
+         "clearanceHeight" : "300",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "ja"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : true,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffDiscount" : "Rabattierung mit BahnCard direkt am Kassenautomaten.",
+         "tariffFreeParkingTime" : "nein",
+         "tariffDiscountEn" : "BahnCard discount available directly at the pay station.",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA), EC-Karte, P Card",
+         "tariffPaymentCustomerCards" : "P Card",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA), EC-Card, P Card"
+      },
+      "tariffPrices" : [ {
+         "id" : 218682,
+         "duration" : "20min"
+      }, {
+         "id" : 218683,
+         "duration" : "30min"
+      }, {
+         "id" : 218684,
+         "duration" : "1hour",
+         "price" : 1.7
+      }, {
+         "id" : 218685,
+         "duration" : "1day",
+         "price" : 17.0
+      }, {
+         "id" : 218686,
+         "duration" : "1dayDiscount",
+         "price" : 12.0
+      }, {
+         "id" : 218687,
+         "duration" : "1week",
+         "price" : 40.0
+      }, {
+         "id" : 218688,
+         "duration" : "1weekDiscount",
+         "price" : 35.0
+      }, {
+         "id" : 218689,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 218690,
+         "duration" : "1monthLongTerm",
+         "price" : 80.0
+      }, {
+         "id" : 218691,
+         "duration" : "1monthReservation",
+         "price" : 150.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100026,
+      "title" : "Berlin Südkreuz P2 Bahnhof Berlin Südkreuz Vorfahrt West",
+      "station" : {
+         "id" : 4859,
+         "name" : "Berlin Südkreuz"
+      },
+      "label" : "P2",
+      "spaceNumber" : "384",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Vorfahrt West - Kiss&Ride",
+      "nameDisplay" : "Bahnhof Berlin Südkreuz Vorfahrt West",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 13.363993,
+         "latitude" : 52.475219
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8011113.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Berlin",
+         "postalCode" : "10829",
+         "street" : "Lotte-Laserstein-Straße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "6",
+      "numberHandicapedPlaces" : "1",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "350",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "20 Min.",
+         "tariffMaxParkingTimeEn" : "Max. 1 day",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark (außer Freiparkschein): Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Tag",
+         "tariffFreeParkingTimeEn" : "20 mins.",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store (except free parking ticket)."
+      },
+      "tariffPrices" : [ {
+         "id" : 218652,
+         "duration" : "20min"
+      }, {
+         "id" : 218653,
+         "duration" : "30min"
+      }, {
+         "id" : 218654,
+         "duration" : "1hour",
+         "price" : 1.5
+      }, {
+         "id" : 218655,
+         "duration" : "1day",
+         "price" : 18.0
+      }, {
+         "id" : 218656,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218657,
+         "duration" : "1week"
+      }, {
+         "id" : 218658,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218659,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 218660,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 218661,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100027,
+      "title" : "Berlin Südkreuz P3 Bahnhof Berlin Südkreuz Vorfahrt Ost",
+      "station" : {
+         "id" : 4859,
+         "name" : "Berlin Südkreuz"
+      },
+      "label" : "P3",
+      "spaceNumber" : "436",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Vorfahrt Ost",
+      "nameDisplay" : "Bahnhof Berlin Südkreuz Vorfahrt Ost",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 13.366315,
+         "latitude" : 52.475416
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8011113.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Berlin",
+         "postalCode" : "12101",
+         "street" : "Erika-Gräfin-von-Brockdorff-Platz"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "20",
+      "numberHandicapedPlaces" : "1",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "350",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 day",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Tag",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 218662,
+         "duration" : "20min"
+      }, {
+         "id" : 218663,
+         "duration" : "30min"
+      }, {
+         "id" : 218664,
+         "duration" : "1hour",
+         "price" : 1.5
+      }, {
+         "id" : 218665,
+         "duration" : "1day",
+         "price" : 18.0
+      }, {
+         "id" : 218666,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218667,
+         "duration" : "1week"
+      }, {
+         "id" : 218668,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218669,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 218670,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 218671,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100028,
+      "title" : "Berlin Südkreuz P4 Bahnhof Berlin Südkreuz Kiss & Ride Ost",
+      "station" : {
+         "id" : 4859,
+         "name" : "Berlin Südkreuz"
+      },
+      "label" : "P4",
+      "spaceNumber" : "385",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Vorfahrt Ost - Kiss&Ride",
+      "nameDisplay" : "Bahnhof Berlin Südkreuz Kiss & Ride Ost",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 13.366469,
+         "latitude" : 52.475295
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8011113.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Berlin",
+         "postalCode" : "10829",
+         "street" : "Erika-Gräfin-von-Brockdorff-Platz"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "8",
+      "numberHandicapedPlaces" : "1",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "350",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "20 Min.",
+         "tariffMaxParkingTimeEn" : "Max. 1 day",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Tag",
+         "tariffFreeParkingTimeEn" : "20 mins.",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 218672,
+         "duration" : "20min"
+      }, {
+         "id" : 218673,
+         "duration" : "30min"
+      }, {
+         "id" : 218674,
+         "duration" : "1hour",
+         "price" : 1.5
+      }, {
+         "id" : 218675,
+         "duration" : "1day",
+         "price" : 18.0
+      }, {
+         "id" : 218676,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218677,
+         "duration" : "1week"
+      }, {
+         "id" : 218678,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218679,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 218680,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 218681,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100029,
+      "title" : "Berlin-Schönefeld Flughafen P1 Parkplatz Berlin-Schönefeld Flughafen",
+      "station" : {
+         "id" : 1821,
+         "name" : "Berlin-Schönefeld Flughafen"
+      },
+      "label" : "P1",
+      "spaceNumber" : "26",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Berlin-Schönefeld Flughafen",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 13.511957,
+         "latitude" : 52.38999
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8010109.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Schönefeld",
+         "postalCode" : "12529",
+         "street" : "Mittelstraße (B96a)"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "75",
+      "numberHandicapedPlaces" : "3",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220842,
+         "duration" : "20min"
+      }, {
+         "id" : 220843,
+         "duration" : "30min"
+      }, {
+         "id" : 220844,
+         "duration" : "1hour",
+         "price" : 2.0
+      }, {
+         "id" : 220845,
+         "duration" : "1day",
+         "price" : 8.0
+      }, {
+         "id" : 220846,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220847,
+         "duration" : "1week",
+         "price" : 40.0
+      }, {
+         "id" : 220848,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220849,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220850,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 220851,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100031,
+      "title" : "Bietigheim-Bissingen P1 Bietigheim-Bissingen P1 Parkhaus Süd",
+      "station" : {
+         "id" : 636,
+         "name" : "Bietigheim-Bissingen"
+      },
+      "label" : "P1",
+      "spaceNumber" : "450",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkhaus Stuttgarter Straße Süd",
+      "nameDisplay" : "Bietigheim-Bissingen P1 Parkhaus Süd",
+      "spaceType" : "Parkhaus",
+      "spaceTypeEn" : "Multi storey car park",
+      "spaceTypeName" : "Parkhaus",
+      "geoLocation" : {
+         "longitude" : 9.138153,
+         "latitude" : 48.947577
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000038.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Bietigheim-Bissingen",
+         "postalCode" : "74321",
+         "street" : "Stuttgarter Straße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "291",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week from the parking ticket machine",
+         "tariffSpecialEn" : "6 month ticket for EUR 102.00 available from the VVS. Season parkers without time-based or unlimited ride pass: Month 25.00",
+         "tariffSpecial" : "Halbjahreskarten zum Preis von EUR 102,00 über den VVS erhältlich (begrenztes Kontingent). Dauerparker mit Zeitfahrkarte, Monat: 25,00 (begrenztes Kontingent)",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 1 Woche am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 218692,
+         "duration" : "20min"
+      }, {
+         "id" : 218693,
+         "duration" : "30min"
+      }, {
+         "id" : 218694,
+         "duration" : "1hour",
+         "price" : 0.5
+      }, {
+         "id" : 218695,
+         "duration" : "1day",
+         "price" : 3.0
+      }, {
+         "id" : 218696,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218697,
+         "duration" : "1week",
+         "price" : 15.0
+      }, {
+         "id" : 218698,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218699,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 218700,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 218701,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100032,
+      "title" : "Bingen (Rhein) Hbf P1 Vorplatz Bingen (Rhein) Hbf",
+      "station" : {
+         "id" : 649,
+         "name" : "Bingen (Rhein) Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "27",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Vorplatz Bingen (Rhein) Hbf",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 7.884668,
+         "latitude" : 49.968506
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000039.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Bingen am Rhein",
+         "postalCode" : "55411",
+         "street" : "Bingerbrücker Straße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "12",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "600",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Woche",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 218702,
+         "duration" : "20min"
+      }, {
+         "id" : 218703,
+         "duration" : "30min",
+         "price" : 0.8
+      }, {
+         "id" : 218704,
+         "duration" : "1hour",
+         "price" : 1.6
+      }, {
+         "id" : 218705,
+         "duration" : "1day",
+         "price" : 7.0
+      }, {
+         "id" : 218706,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218707,
+         "duration" : "1week",
+         "price" : 35.0
+      }, {
+         "id" : 218708,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218709,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 218710,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 218711,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100033,
+      "title" : "Bingen (Rhein) Hbf P2 Parkplatz Bingen (Rhein) Hbf",
+      "station" : {
+         "id" : 649,
+         "name" : "Bingen (Rhein) Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "221",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bingen (Rhein) Hbf",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 7.886195,
+         "latitude" : 49.968198
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000039.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Bingen am Rhein",
+         "postalCode" : "55411",
+         "street" : "Bingerbrücker Straße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "75",
+      "numberHandicapedPlaces" : "1",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 9 days or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 9 Tage oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 218712,
+         "duration" : "20min"
+      }, {
+         "id" : 218713,
+         "duration" : "30min",
+         "price" : 0.7
+      }, {
+         "id" : 218714,
+         "duration" : "1hour",
+         "price" : 1.4
+      }, {
+         "id" : 218715,
+         "duration" : "1day",
+         "price" : 6.0
+      }, {
+         "id" : 218716,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218717,
+         "duration" : "1week",
+         "price" : 24.0
+      }, {
+         "id" : 218718,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218719,
+         "duration" : "1monthVendingMachine",
+         "price" : 38.0
+      }, {
+         "id" : 218720,
+         "duration" : "1monthLongTerm",
+         "price" : 38.0
+      }, {
+         "id" : 218721,
+         "duration" : "1monthReservation",
+         "price" : 60.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100021,
+      "title" : "Böblingen P1 Parkplatz Bahnhof Böblingen",
+      "station" : {
+         "id" : 720,
+         "name" : "Böblingen"
+      },
+      "label" : "P1",
+      "spaceNumber" : "321",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Bahnhof Böblingen",
+      "nameDisplay" : "Parkplatz Bahnhof Böblingen",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.005583,
+         "latitude" : 48.68791
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8001055.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Böblingen",
+         "postalCode" : "71032",
+         "street" : "Talstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "30",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "400",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 1 Woche",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 218732,
+         "duration" : "20min"
+      }, {
+         "id" : 218733,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 218734,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 218735,
+         "duration" : "1day",
+         "price" : 7.0
+      }, {
+         "id" : 218736,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218737,
+         "duration" : "1week",
+         "price" : 35.0
+      }, {
+         "id" : 218738,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218739,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 218740,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 218741,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100034,
+      "title" : "Bochum Hbf P1 Bochum Hbf Parkplatz Klever Weg",
+      "station" : {
+         "id" : 724,
+         "name" : "Bochum Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "341",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Klever Weg",
+      "nameDisplay" : "Bochum Hbf Parkplatz Klever Weg",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 7.220657,
+         "latitude" : 51.47674
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000041.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Bochum",
+         "postalCode" : "44789",
+         "street" : "Klever Weg"
+      },
+      "distance" : "200-250",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "112",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffSpecialEn" : "Night tariff (6pm till 6 am): 2.50",
+         "tariffSpecial" : "Nachttarif (18:00 bis 6:00 Uhr): 2,50",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 218722,
+         "duration" : "20min"
+      }, {
+         "id" : 218723,
+         "duration" : "30min"
+      }, {
+         "id" : 218724,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 218725,
+         "duration" : "1day",
+         "price" : 4.4
+      }, {
+         "id" : 218726,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218727,
+         "duration" : "1week",
+         "price" : 17.6
+      }, {
+         "id" : 218728,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218729,
+         "duration" : "1monthVendingMachine",
+         "price" : 55.0
+      }, {
+         "id" : 218730,
+         "duration" : "1monthLongTerm",
+         "price" : 55.0
+      }, {
+         "id" : 218731,
+         "duration" : "1monthReservation",
+         "price" : 90.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100035,
+      "title" : "Bonn Hbf P1 Bonn Hbf P1 Parkhaus",
+      "station" : {
+         "id" : 767,
+         "name" : "Bonn Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "28",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkhaus Bonn Hauptbahnhof",
+      "nameDisplay" : "Bonn Hbf P1 Parkhaus",
+      "spaceType" : "Parkhaus",
+      "spaceTypeEn" : "Multi storey car park",
+      "spaceTypeName" : "Parkhaus",
+      "geoLocation" : {
+         "longitude" : 7.097349,
+         "latitude" : 50.731338
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000044.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Bonn",
+         "postalCode" : "53115",
+         "street" : "Quantiusstraße 9"
+      },
+      "distance" : "<50",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "166",
+      "numberHandicapedPlaces" : "3",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "clearanceHeight" : "200",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : true,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : true,
+         "isDiscountDbParkAndRail" : true,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffDiscount" : "Bonierung an der DB Information. Rabattierung mit BahnCard direkt am Kassenautomaten.",
+         "tariffFreeParkingTime" : "nein",
+         "tariffDiscountEn" : "Reduction from the DB Information. BahnCard discount available directly at the pay station.",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA)",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA)"
+      },
+      "tariffPrices" : [ {
+         "id" : 218742,
+         "duration" : "20min"
+      }, {
+         "id" : 218743,
+         "duration" : "30min"
+      }, {
+         "id" : 218744,
+         "duration" : "1hour",
+         "price" : 2.2
+      }, {
+         "id" : 218745,
+         "duration" : "1day",
+         "price" : 18.0
+      }, {
+         "id" : 218746,
+         "duration" : "1dayDiscount",
+         "price" : 14.0
+      }, {
+         "id" : 218747,
+         "duration" : "1week"
+      }, {
+         "id" : 218748,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218749,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 218750,
+         "duration" : "1monthLongTerm",
+         "price" : 110.0
+      }, {
+         "id" : 218751,
+         "duration" : "1monthReservation",
+         "price" : 150.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100036,
+      "title" : "Bonn-Bad Godesberg P1 Bahnhof Bad Godesberg Vorderseite",
+      "station" : {
+         "id" : 768,
+         "name" : "Bonn-Bad Godesberg"
+      },
+      "label" : "P1",
+      "spaceNumber" : "279",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Bahnhof Bad Godesberg Vorderseite",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 7.160621,
+         "latitude" : 50.682847
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8001082.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Bonn",
+         "postalCode" : "53173",
+         "street" : "Moltkestraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "27",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 11 days or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 11 Tage oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 218752,
+         "duration" : "20min"
+      }, {
+         "id" : 218753,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 218754,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 218755,
+         "duration" : "1day",
+         "price" : 3.8
+      }, {
+         "id" : 218756,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218757,
+         "duration" : "1week",
+         "price" : 19.0
+      }, {
+         "id" : 218758,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218759,
+         "duration" : "1monthVendingMachine",
+         "price" : 35.0
+      }, {
+         "id" : 218760,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 218761,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100037,
+      "title" : "Bonn-Bad Godesberg P2 Bahnhof Bad Godesberg Von-Groote-Pl. Süd",
+      "station" : {
+         "id" : 768,
+         "name" : "Bonn-Bad Godesberg"
+      },
+      "label" : "P2",
+      "spaceNumber" : "381",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Bahnhof Bad Godesberg Von-Groote-Pl. Süd",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 7.161051,
+         "latitude" : 50.683587
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8001082.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Bonn",
+         "postalCode" : "53173",
+         "street" : "Von-Groote-Platz 4"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "71",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 218762,
+         "duration" : "20min"
+      }, {
+         "id" : 218763,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 218764,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 218765,
+         "duration" : "1day",
+         "price" : 3.2
+      }, {
+         "id" : 218766,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218767,
+         "duration" : "1week",
+         "price" : 16.0
+      }, {
+         "id" : 218768,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218769,
+         "duration" : "1monthVendingMachine",
+         "price" : 35.0
+      }, {
+         "id" : 218770,
+         "duration" : "1monthLongTerm",
+         "price" : 35.0
+      }, {
+         "id" : 218771,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100038,
+      "title" : "Bonn-Bad Godesberg P3 Bahnhof Bad Godesberg Von-Groote-Platz",
+      "station" : {
+         "id" : 768,
+         "name" : "Bonn-Bad Godesberg"
+      },
+      "label" : "P3",
+      "spaceNumber" : "382",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Bahnhof Bad Godesberg Von-Groote-Platz",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 7.159511,
+         "latitude" : 50.684606
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8001082.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Bonn",
+         "postalCode" : "53173",
+         "street" : "Von-Groote-Platz 1"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "37",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 218772,
+         "duration" : "20min"
+      }, {
+         "id" : 218773,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 218774,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 218775,
+         "duration" : "1day",
+         "price" : 3.2
+      }, {
+         "id" : 218776,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218777,
+         "duration" : "1week",
+         "price" : 16.0
+      }, {
+         "id" : 218778,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218779,
+         "duration" : "1monthVendingMachine",
+         "price" : 35.0
+      }, {
+         "id" : 218780,
+         "duration" : "1monthLongTerm",
+         "price" : 35.0
+      }, {
+         "id" : 218781,
+         "duration" : "1monthReservation",
+         "price" : 50.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100039,
+      "title" : "Bonn-Mehlem P1 Parkplatz Bahnhof Bonn-Mehlem",
+      "station" : {
+         "id" : 771,
+         "name" : "Bonn-Mehlem"
+      },
+      "label" : "P1",
+      "spaceNumber" : "445",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Bahnhof Bonn-Mehlem",
+      "nameDisplay" : "Parkplatz Bahnhof Bonn-Mehlem",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 7.181252,
+         "latitude" : 50.669584
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8001085.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Bonn",
+         "postalCode" : "53179",
+         "street" : "Mainzer Straße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "70",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 218782,
+         "duration" : "20min"
+      }, {
+         "id" : 218783,
+         "duration" : "30min"
+      }, {
+         "id" : 218784,
+         "duration" : "1hour",
+         "price" : 0.5
+      }, {
+         "id" : 218785,
+         "duration" : "1day",
+         "price" : 1.5
+      }, {
+         "id" : 218786,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218787,
+         "duration" : "1week",
+         "price" : 7.5
+      }, {
+         "id" : 218788,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218789,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 218790,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 218791,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100040,
+      "title" : "Braunschweig Hbf P1 Braunschweig Hbf P1 Parkplatz Nord",
+      "station" : {
+         "id" : 835,
+         "name" : "Braunschweig Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "29",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Hauptbahnhof Nord",
+      "nameDisplay" : "Braunschweig Hbf P1 Parkplatz Nord",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 10.54043,
+         "latitude" : 52.253916
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000049.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Braunschweig",
+         "postalCode" : "38102",
+         "street" : "Willy-Brandt-Platz",
+         "supplement" : "ehem. Berliner Platz"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "148",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "260",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : true,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffDiscount" : "mit BahnCard direkt am Kassenautomaten.",
+         "tariffFreeParkingTime" : "nein",
+         "tariffSpecialEn" : "15 minutes Kiss&Ride: 0.30. Evening tariff: 6.00pm - 2.00am: 3.00 max.",
+         "tariffSpecial" : "15 Minuten Kiss&Ride: 0,30. Abendtarif: 18:00 bis 02:00 Uhr: 3,00 maximal",
+         "tariffDiscountEn" : "BahnCard discount at the pay station.",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA)",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA)"
+      },
+      "tariffPrices" : [ {
+         "id" : 218792,
+         "duration" : "20min"
+      }, {
+         "id" : 218793,
+         "duration" : "30min"
+      }, {
+         "id" : 218794,
+         "duration" : "1hour",
+         "price" : 1.5
+      }, {
+         "id" : 218795,
+         "duration" : "1day",
+         "price" : 10.0
+      }, {
+         "id" : 218796,
+         "duration" : "1dayDiscount",
+         "price" : 8.5
+      }, {
+         "id" : 218797,
+         "duration" : "1week"
+      }, {
+         "id" : 218798,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218799,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 218800,
+         "duration" : "1monthLongTerm",
+         "price" : 100.0
+      }, {
+         "id" : 218801,
+         "duration" : "1monthReservation",
+         "price" : 150.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100041,
+      "title" : "Braunschweig Hbf P2 Braunschweig Hbf Ackerstraße",
+      "station" : {
+         "id" : 835,
+         "name" : "Braunschweig Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "30",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Hauptbahnhof Süd",
+      "nameDisplay" : "Braunschweig Hbf Ackerstraße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 10.542638,
+         "latitude" : 52.252212
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000049.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Braunschweig",
+         "postalCode" : "38102",
+         "street" : "Ackerstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "385",
+      "numberHandicapedPlaces" : "6",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "285",
+         "clearanceHeight" : "229.99999999999997",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : true,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 11 days or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffPointOfSale" : "Park&Rail-Karten an Verkaufsstellen der DB.",
+         "tariffPointOfSaleEn" : "Park&Rail cards available from DB points of sale.",
+         "tariffMaxParkingTime" : "Max. 11 Tage oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 218802,
+         "duration" : "20min"
+      }, {
+         "id" : 218803,
+         "duration" : "30min",
+         "price" : 0.8
+      }, {
+         "id" : 218804,
+         "duration" : "1hour",
+         "price" : 1.6
+      }, {
+         "id" : 218805,
+         "duration" : "1day",
+         "price" : 6.5
+      }, {
+         "id" : 218806,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218807,
+         "duration" : "1week",
+         "price" : 32.5
+      }, {
+         "id" : 218808,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218809,
+         "duration" : "1monthVendingMachine",
+         "price" : 63.0
+      }, {
+         "id" : 218810,
+         "duration" : "1monthLongTerm",
+         "price" : 63.0
+      }, {
+         "id" : 218811,
+         "duration" : "1monthReservation",
+         "price" : 102.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100042,
+      "title" : "Braunschweig Hbf P3 Braunschweig Hbf Willy-Brandt-Platz West",
+      "station" : {
+         "id" : 835,
+         "name" : "Braunschweig Hbf"
+      },
+      "label" : "P3",
+      "spaceNumber" : "335",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Braunschweig Hbf Willy-Brandt-Platz West",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 10.538076,
+         "latitude" : 52.251725
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000049.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Braunschweig",
+         "postalCode" : "38102",
+         "street" : "Willy-Brandt-Platz",
+         "supplement" : "ehem. Berliner Platz"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "72",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 11 days or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 11 Tage oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 218812,
+         "duration" : "20min"
+      }, {
+         "id" : 218813,
+         "duration" : "30min",
+         "price" : 0.8
+      }, {
+         "id" : 218814,
+         "duration" : "1hour",
+         "price" : 1.6
+      }, {
+         "id" : 218815,
+         "duration" : "1day",
+         "price" : 6.5
+      }, {
+         "id" : 218816,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218817,
+         "duration" : "1week",
+         "price" : 32.5
+      }, {
+         "id" : 218818,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218819,
+         "duration" : "1monthVendingMachine",
+         "price" : 63.0
+      }, {
+         "id" : 218820,
+         "duration" : "1monthLongTerm",
+         "price" : 63.0
+      }, {
+         "id" : 218821,
+         "duration" : "1monthReservation",
+         "price" : 102.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100043,
+      "title" : "Bremen Hbf P1 Bremen Hbf P1 Hochgarage am Bahnhof",
+      "station" : {
+         "id" : 855,
+         "name" : "Bremen Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "31",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Hochgarage am Bahnhof",
+      "nameDisplay" : "Bremen Hbf P1 Hochgarage am Bahnhof",
+      "spaceType" : "Parkhaus",
+      "spaceTypeEn" : "Multi storey car park",
+      "spaceTypeName" : "Parkhaus",
+      "geoLocation" : {
+         "longitude" : 8.81429,
+         "latitude" : 53.080297
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000050.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Bremen",
+         "postalCode" : "28195",
+         "street" : "Rembertiring 6"
+      },
+      "distance" : "200-250",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "Mo-Fr: 06:00 - 22:00 Uhr, Sa: 07:00 - 24:00 Uhr, So+F: geschlossen. Ausfahrt mit Parkticket jederzeit möglich.",
+      "openingHoursEn" : "Mon-Fri: 6:00am - 10:00pm, Sat: 7:00am - 12midnight, Sun + public hols: closed. Exit possible at any time with parking ticket. ",
+      "numberParkingPlaces" : "289",
+      "numberHandicapedPlaces" : "2",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "350",
+         "clearanceHeight" : "190",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : true,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffSpecialEn" : "With P Card: 1 hour: 1.00, 1 day: 4.10",
+         "tariffSpecial" : "Mit P Card: 1 Stunde 1,00, 1 Tag 4,10",
+         "tariffRemarks" : "Der Tagestarif gilt je Parkvorgang pro Kalendertag bis 03:00 Uhr früh.",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (MasterCard, VISA), P Card",
+         "tariffPaymentCustomerCards" : "P Card",
+         "tariffRemarksEn" : "The daily tariff applies per parking session per calendar day until 3.00am. With P Card: 1 hour: 1.00, 1 day: 4.10",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (MasterCard, VISA), P Card"
+      },
+      "tariffPrices" : [ {
+         "id" : 218822,
+         "duration" : "20min"
+      }, {
+         "id" : 218823,
+         "duration" : "30min"
+      }, {
+         "id" : 218824,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 218825,
+         "duration" : "1day",
+         "price" : 4.5
+      }, {
+         "id" : 218826,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218827,
+         "duration" : "1week"
+      }, {
+         "id" : 218828,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218829,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 218830,
+         "duration" : "1monthLongTerm",
+         "price" : 85.0
+      }, {
+         "id" : 218831,
+         "duration" : "1monthReservation",
+         "price" : 115.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100044,
+      "title" : "Bremen-Vegesack P1 Vorfahrt Bahnhof Bremen-Vegesack",
+      "station" : {
+         "id" : 866,
+         "name" : "Bremen-Vegesack"
+      },
+      "label" : "P1",
+      "spaceNumber" : "32",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Vorfahrt Bahnhof Bremen-Vegesack",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.628907,
+         "latitude" : 53.169791
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8001166.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Bremen",
+         "postalCode" : "28757",
+         "street" : "Sagerstraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "7",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 day",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Tag",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 218832,
+         "duration" : "20min"
+      }, {
+         "id" : 218833,
+         "duration" : "30min",
+         "price" : 0.55
+      }, {
+         "id" : 218834,
+         "duration" : "1hour",
+         "price" : 1.1
+      }, {
+         "id" : 218835,
+         "duration" : "1day",
+         "price" : 3.3
+      }, {
+         "id" : 218836,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218837,
+         "duration" : "1week"
+      }, {
+         "id" : 218838,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218839,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 218840,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 218841,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100045,
+      "title" : "Bremen-Vegesack P2 Parkplatz Bahnhof Bremen-Vegesack",
+      "station" : {
+         "id" : 866,
+         "name" : "Bremen-Vegesack"
+      },
+      "label" : "P2",
+      "spaceNumber" : "33",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Bremen-Vegesack",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.6298,
+         "latitude" : 53.170282
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8001166.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Bremen",
+         "postalCode" : "28758",
+         "street" : "Sagerstraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "103",
+      "numberHandicapedPlaces" : "3",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 218842,
+         "duration" : "20min"
+      }, {
+         "id" : 218843,
+         "duration" : "30min"
+      }, {
+         "id" : 218844,
+         "duration" : "1hour"
+      }, {
+         "id" : 218845,
+         "duration" : "1day",
+         "price" : 2.0
+      }, {
+         "id" : 218846,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218847,
+         "duration" : "1week",
+         "price" : 10.0
+      }, {
+         "id" : 218848,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218849,
+         "duration" : "1monthVendingMachine",
+         "price" : 25.0
+      }, {
+         "id" : 218850,
+         "duration" : "1monthLongTerm",
+         "price" : 25.0
+      }, {
+         "id" : 218851,
+         "duration" : "1monthReservation",
+         "price" : 30.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100046,
+      "title" : "Bruchsal P1 Vorfahrt Bahnhof Bruchsal",
+      "station" : {
+         "id" : 904,
+         "name" : "Bruchsal"
+      },
+      "label" : "P1",
+      "spaceNumber" : "36",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Vorfahrt",
+      "nameDisplay" : "Vorfahrt Bahnhof Bruchsal",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.590533,
+         "latitude" : 49.124223
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000055.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Bruchsal",
+         "postalCode" : "76646",
+         "street" : "Bahnhofsplatz"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "20",
+      "numberHandicapedPlaces" : "1",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 day",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Tag",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 218852,
+         "duration" : "20min"
+      }, {
+         "id" : 218853,
+         "duration" : "30min",
+         "price" : 0.8
+      }, {
+         "id" : 218854,
+         "duration" : "1hour",
+         "price" : 1.6
+      }, {
+         "id" : 218855,
+         "duration" : "1day",
+         "price" : 8.0
+      }, {
+         "id" : 218856,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218857,
+         "duration" : "1week"
+      }, {
+         "id" : 218858,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218859,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 218860,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 218861,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100047,
+      "title" : "Bruchsal P2 Bruchsal Bahnhofsplatz rechts",
+      "station" : {
+         "id" : 904,
+         "name" : "Bruchsal"
+      },
+      "label" : "P2",
+      "spaceNumber" : "35",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Bahnhofsplatz rechts",
+      "nameDisplay" : "Bruchsal Bahnhofsplatz rechts",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.591019,
+         "latitude" : 49.125335
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000055.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Bruchsal",
+         "postalCode" : "76646",
+         "street" : "Bahnhofsplatz"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "45",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Woche",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 218862,
+         "duration" : "20min"
+      }, {
+         "id" : 218863,
+         "duration" : "30min"
+      }, {
+         "id" : 218864,
+         "duration" : "1hour",
+         "price" : 1.5
+      }, {
+         "id" : 218865,
+         "duration" : "1day",
+         "price" : 6.5
+      }, {
+         "id" : 218866,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218867,
+         "duration" : "1week",
+         "price" : 26.0
+      }, {
+         "id" : 218868,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218869,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 218870,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 218871,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100048,
+      "title" : "Bruchsal P3 Bruchsal Bahnhofsplatz links",
+      "station" : {
+         "id" : 904,
+         "name" : "Bruchsal"
+      },
+      "label" : "P3",
+      "spaceNumber" : "34",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Bahnhofsplatz links",
+      "nameDisplay" : "Bruchsal Bahnhofsplatz links",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.590012,
+         "latitude" : 49.12341
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000055.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Bruchsal",
+         "postalCode" : "76646",
+         "street" : "Bahnhofsplatz"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "90",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "320",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 10 days or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 10 Tage oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 218872,
+         "duration" : "20min"
+      }, {
+         "id" : 218873,
+         "duration" : "30min"
+      }, {
+         "id" : 218874,
+         "duration" : "1hour",
+         "price" : 1.5
+      }, {
+         "id" : 218875,
+         "duration" : "1day",
+         "price" : 6.5
+      }, {
+         "id" : 218876,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218877,
+         "duration" : "1week",
+         "price" : 26.0
+      }, {
+         "id" : 218878,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218879,
+         "duration" : "1monthVendingMachine",
+         "price" : 50.0
+      }, {
+         "id" : 218880,
+         "duration" : "1monthLongTerm",
+         "price" : 50.0
+      }, {
+         "id" : 218881,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100049,
+      "title" : "Bruchsal P4 Parkplatz Bahnhof Bruchsal Nord",
+      "station" : {
+         "id" : 904,
+         "name" : "Bruchsal"
+      },
+      "label" : "P4",
+      "spaceNumber" : "454",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Nord",
+      "nameDisplay" : "Parkplatz Bahnhof Bruchsal Nord",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.5911,
+         "latitude" : 49.126212
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000055.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Bruchsal",
+         "postalCode" : "76646",
+         "street" : "Bahnhofstraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "20",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 1 Woche",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 218882,
+         "duration" : "20min"
+      }, {
+         "id" : 218883,
+         "duration" : "30min"
+      }, {
+         "id" : 218884,
+         "duration" : "1hour",
+         "price" : 1.5
+      }, {
+         "id" : 218885,
+         "duration" : "1day",
+         "price" : 6.0
+      }, {
+         "id" : 218886,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218887,
+         "duration" : "1week",
+         "price" : 24.0
+      }, {
+         "id" : 218888,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218889,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 218890,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 218891,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100050,
+      "title" : "Coburg P1 Parkplatz Bahnhof Coburg",
+      "station" : {
+         "id" : 1059,
+         "name" : "Coburg"
+      },
+      "label" : "P1",
+      "spaceNumber" : "460",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Bahnhof Coburg",
+      "nameDisplay" : "Parkplatz Bahnhof Coburg",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 10.958163,
+         "latitude" : 50.260454
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8001338.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Coburg",
+         "postalCode" : "96450",
+         "street" : "Lossaustraße"
+      },
+      "distance" : "200-250",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "56",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks from the parking ticket machine",
+         "tariffSpecialEn" : "Limited availability of season parking",
+         "tariffSpecial" : "Begrenztes Kontingent Dauerparken",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 218892,
+         "duration" : "20min"
+      }, {
+         "id" : 218893,
+         "duration" : "30min"
+      }, {
+         "id" : 218894,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 218895,
+         "duration" : "1day",
+         "price" : 4.0
+      }, {
+         "id" : 218896,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218897,
+         "duration" : "1week",
+         "price" : 20.0
+      }, {
+         "id" : 218898,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218899,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 218900,
+         "duration" : "1monthLongTerm",
+         "price" : 70.0
+      }, {
+         "id" : 218901,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100051,
+      "title" : "Coswig (Bz Dresden) P1 Parkplatz Bahnhof Coswig",
+      "station" : {
+         "id" : 1076,
+         "name" : "Coswig (Bz Dresden)"
+      },
+      "label" : "P1",
+      "spaceNumber" : "38",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Coswig",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 13.58021,
+         "latitude" : 51.123028
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8010072.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Coswig in Sachsen",
+         "postalCode" : "01640",
+         "street" : "Sachsenstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "34",
+      "numberHandicapedPlaces" : "2",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 3 days or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 3 Tage oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 218902,
+         "duration" : "20min"
+      }, {
+         "id" : 218903,
+         "duration" : "30min"
+      }, {
+         "id" : 218904,
+         "duration" : "1hour",
+         "price" : 0.5
+      }, {
+         "id" : 218905,
+         "duration" : "1day",
+         "price" : 2.0
+      }, {
+         "id" : 218906,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218907,
+         "duration" : "1week"
+      }, {
+         "id" : 218908,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218909,
+         "duration" : "1monthVendingMachine",
+         "price" : 8.0
+      }, {
+         "id" : 218910,
+         "duration" : "1monthLongTerm",
+         "price" : 8.0
+      }, {
+         "id" : 218911,
+         "duration" : "1monthReservation",
+         "price" : 20.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100052,
+      "title" : "Crailsheim P1 Parkplatz Bahnhof Crailsheim",
+      "station" : {
+         "id" : 1079,
+         "name" : "Crailsheim"
+      },
+      "label" : "P1",
+      "spaceNumber" : "39",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Crailsheim",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 10.064123,
+         "latitude" : 49.139566
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000067.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Crailsheim",
+         "postalCode" : "74565",
+         "street" : "Zum Bahnhof"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "78",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "450",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 218912,
+         "duration" : "20min"
+      }, {
+         "id" : 218913,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 218914,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 218915,
+         "duration" : "1day",
+         "price" : 3.5
+      }, {
+         "id" : 218916,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218917,
+         "duration" : "1week",
+         "price" : 17.5
+      }, {
+         "id" : 218918,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218919,
+         "duration" : "1monthVendingMachine",
+         "price" : 50.0
+      }, {
+         "id" : 218920,
+         "duration" : "1monthLongTerm",
+         "price" : 50.0
+      }, {
+         "id" : 218921,
+         "duration" : "1monthReservation",
+         "price" : 70.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100053,
+      "title" : "Crailsheim P2 Parkplatz Bahnhof Crailsheim Rückseite",
+      "station" : {
+         "id" : 1079,
+         "name" : "Crailsheim"
+      },
+      "label" : "P2",
+      "spaceNumber" : "215",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Crailsheim Rückseite",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 10.066097,
+         "latitude" : 49.137868
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000067.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Crailsheim",
+         "postalCode" : "74564",
+         "street" : "Worthingtonstraße, B290"
+      },
+      "distance" : "200-250",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "73",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "450",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 218922,
+         "duration" : "20min"
+      }, {
+         "id" : 218923,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 218924,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 218925,
+         "duration" : "1day",
+         "price" : 2.5
+      }, {
+         "id" : 218926,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218927,
+         "duration" : "1week",
+         "price" : 12.5
+      }, {
+         "id" : 218928,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218929,
+         "duration" : "1monthVendingMachine",
+         "price" : 45.0
+      }, {
+         "id" : 218930,
+         "duration" : "1monthLongTerm",
+         "price" : 45.0
+      }, {
+         "id" : 218931,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100059,
+      "title" : "Delmenhorst P1 Parkplatz Bahnhof Delmenhorst rechts",
+      "station" : {
+         "id" : 1159,
+         "name" : "Delmenhorst"
+      },
+      "label" : "P1",
+      "spaceNumber" : "292",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Delmenhorst rechts",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.632163,
+         "latitude" : 53.052769
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000070.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Delmenhorst",
+         "postalCode" : "27749",
+         "street" : "Wittekindstraße 2"
+      },
+      "distance" : "100-149",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "24",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "350",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 10 days or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 10 Tage oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 218932,
+         "duration" : "20min"
+      }, {
+         "id" : 218933,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 218934,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 218935,
+         "duration" : "1day",
+         "price" : 3.0
+      }, {
+         "id" : 218936,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218937,
+         "duration" : "1week",
+         "price" : 15.0
+      }, {
+         "id" : 218938,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218939,
+         "duration" : "1monthVendingMachine",
+         "price" : 25.0
+      }, {
+         "id" : 218940,
+         "duration" : "1monthLongTerm",
+         "price" : 25.0
+      }, {
+         "id" : 218941,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100060,
+      "title" : "Dillingen (Saar) P1 Parkplatz Bahnhof Dillingen",
+      "station" : {
+         "id" : 1216,
+         "name" : "Dillingen (Saar)"
+      },
+      "label" : "P1",
+      "spaceNumber" : "424",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Bahnhof Dillingen",
+      "nameDisplay" : "Parkplatz Bahnhof Dillingen",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 6.722298,
+         "latitude" : 49.353183
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000075.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Dillingen an der Saar",
+         "postalCode" : "66763",
+         "street" : "Berkheimstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "170",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 11 days or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 11 Tage oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 218942,
+         "duration" : "20min"
+      }, {
+         "id" : 218943,
+         "duration" : "30min"
+      }, {
+         "id" : 218944,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 218945,
+         "duration" : "1day",
+         "price" : 2.2
+      }, {
+         "id" : 218946,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218947,
+         "duration" : "1week",
+         "price" : 11.0
+      }, {
+         "id" : 218948,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218949,
+         "duration" : "1monthVendingMachine",
+         "price" : 22.0
+      }, {
+         "id" : 218950,
+         "duration" : "1monthLongTerm",
+         "price" : 22.0
+      }, {
+         "id" : 218951,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100061,
+      "title" : "Dortmund Hbf P2 Parkplatz Dortmund Hbf Treibstraße",
+      "station" : {
+         "id" : 1289,
+         "name" : "Dortmund Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "410",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Hauptbahnhof Nord / Treibstraße",
+      "nameDisplay" : "Parkplatz Dortmund Hbf Treibstraße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 7.457624,
+         "latitude" : 51.518723
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000080.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Dortmund",
+         "postalCode" : "44137",
+         "street" : "Treibstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "350",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks from the parking ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen am Automaten",
+         "tarifNotesEn" : "The station is not handicapped accessible from this car park.",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffNotes" : "Der Zugang zum Bahnhof ist nicht barrierefrei.",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 218952,
+         "duration" : "20min"
+      }, {
+         "id" : 218953,
+         "duration" : "30min",
+         "price" : 0.5
+      }, {
+         "id" : 218954,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 218955,
+         "duration" : "1day",
+         "price" : 3.0
+      }, {
+         "id" : 218956,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218957,
+         "duration" : "1week",
+         "price" : 15.0
+      }, {
+         "id" : 218958,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218959,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 218960,
+         "duration" : "1monthLongTerm",
+         "price" : 60.0
+      }, {
+         "id" : 218961,
+         "duration" : "1monthReservation",
+         "price" : 100.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100062,
+      "title" : "Dortmund Hbf P3 Parkplatz Dortmund Hbf Königswall rechts",
+      "station" : {
+         "id" : 1289,
+         "name" : "Dortmund Hbf"
+      },
+      "label" : "P3",
+      "spaceNumber" : "417",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Hauptbahnhof Königswall",
+      "nameDisplay" : "Parkplatz Dortmund Hbf Königswall rechts",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 7.461422,
+         "latitude" : 51.517324
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000080.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Dortmund",
+         "postalCode" : "44137",
+         "street" : "Königswall 13-15"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "35",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 day",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Tag",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 218962,
+         "duration" : "20min"
+      }, {
+         "id" : 218963,
+         "duration" : "30min"
+      }, {
+         "id" : 218964,
+         "duration" : "1hour",
+         "price" : 1.4
+      }, {
+         "id" : 218965,
+         "duration" : "1day",
+         "price" : 7.0
+      }, {
+         "id" : 218966,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218967,
+         "duration" : "1week"
+      }, {
+         "id" : 218968,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218969,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 218970,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 218971,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100065,
+      "title" : "Duisburg Hbf P1 Parkplatz Duisburg Hbf Otto-Keller-Str.",
+      "station" : {
+         "id" : 1374,
+         "name" : "Duisburg Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "42",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Duisburg Hauptbahnhof Osteingang",
+      "nameDisplay" : "Parkplatz Duisburg Hbf Otto-Keller-Str.",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 6.776956,
+         "latitude" : 51.427761
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000086.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Duisburg",
+         "postalCode" : "47057",
+         "street" : "Otto-Keller-Straße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "93",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "250",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Woche",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219022,
+         "duration" : "20min"
+      }, {
+         "id" : 219023,
+         "duration" : "30min",
+         "price" : 0.75
+      }, {
+         "id" : 219024,
+         "duration" : "1hour",
+         "price" : 1.5
+      }, {
+         "id" : 219025,
+         "duration" : "1day",
+         "price" : 6.8
+      }, {
+         "id" : 219026,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219027,
+         "duration" : "1week",
+         "price" : 34.0
+      }, {
+         "id" : 219028,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219029,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219030,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219031,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100066,
+      "title" : "Duisburg Hbf P2 Duisburg Hbf P2 Parkhaus",
+      "station" : {
+         "id" : 1374,
+         "name" : "Duisburg Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "390",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkhaus Duisburg Hauptbahnhof",
+      "nameDisplay" : "Duisburg Hbf P2 Parkhaus",
+      "spaceType" : "Parkhaus",
+      "spaceTypeEn" : "Multi storey car park",
+      "spaceTypeName" : "Parkhaus",
+      "geoLocation" : {
+         "longitude" : 6.778361,
+         "latitude" : 51.43043
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000086.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Duisburg",
+         "postalCode" : "47057",
+         "street" : "Neudorfer Straße"
+      },
+      "distance" : "100-149",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "398",
+      "numberHandicapedPlaces" : "8",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : true,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffDiscount" : "Rabattierung mit BahnCard direkt am Kassenautomaten.",
+         "tariffFreeParkingTime" : "nein",
+         "tariffSpecialEn" : "Cinema tariff: 6.00pm - 6.00am: 3.00 max.",
+         "tariffSpecial" : "Kinotarif: 18:00 bis 06:00 Uhr: 3,00 maximal",
+         "tariffDiscountEn" : "BahnCard discount available directly at the pay station.",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA), P Card",
+         "tariffPaymentCustomerCards" : "P Card",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA), P Card"
+      },
+      "tariffPrices" : [ {
+         "id" : 219032,
+         "duration" : "20min"
+      }, {
+         "id" : 219033,
+         "duration" : "30min"
+      }, {
+         "id" : 219034,
+         "duration" : "1hour",
+         "price" : 1.5
+      }, {
+         "id" : 219035,
+         "duration" : "1day",
+         "price" : 8.0
+      }, {
+         "id" : 219036,
+         "duration" : "1dayDiscount",
+         "price" : 6.5
+      }, {
+         "id" : 219037,
+         "duration" : "1week"
+      }, {
+         "id" : 219038,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219039,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219040,
+         "duration" : "1monthLongTerm",
+         "price" : 110.0
+      }, {
+         "id" : 219041,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100067,
+      "title" : "Duisburg Hbf P3 Parkplatz Duisburg Hbf Wuhanstraße Nord",
+      "station" : {
+         "id" : 1374,
+         "name" : "Duisburg Hbf"
+      },
+      "label" : "P3",
+      "spaceNumber" : "278",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Duisburg Hauptbahnhof Westseite",
+      "nameDisplay" : "Parkplatz Duisburg Hbf Wuhanstraße Nord",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 6.7734,
+         "latitude" : 51.428952
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000086.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Duisburg",
+         "postalCode" : "47057",
+         "street" : "Wuhanstraße"
+      },
+      "distance" : "150-199",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "70",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 day",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Tag",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 360586,
+         "duration" : "20min"
+      }, {
+         "id" : 360587,
+         "duration" : "30min"
+      }, {
+         "id" : 360588,
+         "duration" : "1hour",
+         "price" : 1.5
+      }, {
+         "id" : 360589,
+         "duration" : "1day",
+         "price" : 6.5
+      }, {
+         "id" : 360590,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 360591,
+         "duration" : "1week"
+      }, {
+         "id" : 360592,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 360593,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 360594,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 360595,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100068,
+      "title" : "Duisburg Hbf P4 Parkplatz Duisburg Hbf Wuhanstraße Süd",
+      "station" : {
+         "id" : 1374,
+         "name" : "Duisburg Hbf"
+      },
+      "label" : "P4",
+      "spaceNumber" : "446",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Duisburg Hauptbahnhof Westseite",
+      "nameDisplay" : "Parkplatz Duisburg Hbf Wuhanstraße Süd",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 6.773211,
+         "latitude" : 51.428475
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000086.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Duisburg",
+         "postalCode" : "47057",
+         "street" : "Wuhanstraße"
+      },
+      "distance" : "200-250",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "243",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks from the parking ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219052,
+         "duration" : "20min"
+      }, {
+         "id" : 219053,
+         "duration" : "30min"
+      }, {
+         "id" : 219054,
+         "duration" : "1hour",
+         "price" : 1.5
+      }, {
+         "id" : 219055,
+         "duration" : "1day",
+         "price" : 4.0
+      }, {
+         "id" : 219056,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219057,
+         "duration" : "1week",
+         "price" : 20.0
+      }, {
+         "id" : 219058,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219059,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219060,
+         "duration" : "1monthLongTerm",
+         "price" : 65.0
+      }, {
+         "id" : 219061,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100054,
+      "title" : "Düren P1 Düren P1 Parkplatz Ludwig-Erhardt-Platz",
+      "station" : {
+         "id" : 1392,
+         "name" : "Düren"
+      },
+      "label" : "P1",
+      "spaceNumber" : "419",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Ludwig-Erhard-Platz",
+      "nameDisplay" : "Düren P1 Parkplatz Ludwig-Erhardt-Platz",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 6.48081,
+         "latitude" : 50.809541
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000084.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Düren",
+         "postalCode" : "52351",
+         "street" : "Ludwig-Erhard-Platz",
+         "supplement" : "über Eisenbahnstraße",
+         "supplementEn" : "via Eisenbahnstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "187",
+      "numberHandicapedPlaces" : "4",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 10 days",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 10 Tage",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 218972,
+         "duration" : "20min"
+      }, {
+         "id" : 218973,
+         "duration" : "30min"
+      }, {
+         "id" : 218974,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 218975,
+         "duration" : "1day",
+         "price" : 3.0
+      }, {
+         "id" : 218976,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 218977,
+         "duration" : "1week",
+         "price" : 15.0
+      }, {
+         "id" : 218978,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 218979,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 218980,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 218981,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100055,
+      "title" : "Düren P2 Parkplatz Bahnhof Düren Eisenbahnstraße",
+      "station" : {
+         "id" : 1392,
+         "name" : "Düren"
+      },
+      "label" : "P2",
+      "spaceNumber" : "420",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Eisenbahnstraße",
+      "nameDisplay" : "Parkplatz Bahnhof Düren Eisenbahnstraße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 6.481233,
+         "latitude" : 50.810312
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000084.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Düren",
+         "postalCode" : "52349",
+         "street" : "Eisenbahnstraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "234",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 293517,
+         "duration" : "20min"
+      }, {
+         "id" : 293518,
+         "duration" : "30min"
+      }, {
+         "id" : 293519,
+         "duration" : "1hour",
+         "price" : 0.5
+      }, {
+         "id" : 293520,
+         "duration" : "1day",
+         "price" : 2.5
+      }, {
+         "id" : 293521,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 293522,
+         "duration" : "1week",
+         "price" : 12.5
+      }, {
+         "id" : 293523,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 293524,
+         "duration" : "1monthVendingMachine",
+         "price" : 30.0
+      }, {
+         "id" : 293525,
+         "duration" : "1monthLongTerm",
+         "price" : 30.0
+      }, {
+         "id" : 293526,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100056,
+      "title" : "Düsseldorf Hbf P1 Vorplatz Düsseldorf Hbf links",
+      "station" : {
+         "id" : 1401,
+         "name" : "Düsseldorf Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "45",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Vorplatz Düsseldorf Hbf links",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 6.793745,
+         "latitude" : 51.221361
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000085.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Düsseldorf",
+         "postalCode" : "40227",
+         "street" : "Konrad-Adenauer-Platz 13-14"
+      },
+      "distance" : "150-199",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "31",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "outOfServiceText" : "",
+      "outOfServiceTextEn" : "",
+      "spaceInfo" : {
+         "clearanceWidth" : "350",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 3 days",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffSpecialEn" : "Evening tariff (6:00pm to 3:00am): 5.00",
+         "tariffSpecial" : "Abendtarif (18:00 bis 3:00 Uhr): 5,00",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 3 Tage",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffNotes" : "",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 336067,
+         "duration" : "20min"
+      }, {
+         "id" : 336068,
+         "duration" : "30min",
+         "price" : 2.0
+      }, {
+         "id" : 336069,
+         "duration" : "1hour",
+         "price" : 4.0
+      }, {
+         "id" : 336070,
+         "duration" : "1day",
+         "price" : 25.0
+      }, {
+         "id" : 336071,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 336072,
+         "duration" : "1week"
+      }, {
+         "id" : 336073,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 336074,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 336075,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 336076,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100057,
+      "title" : "Düsseldorf Hbf P2 Vorplatz Düsseldorf Hbf Uhrenturm",
+      "station" : {
+         "id" : 1401,
+         "name" : "Düsseldorf Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "222",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Vorplatz Düsseldorf Hbf Uhrenturm",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 6.791614,
+         "latitude" : 51.219731
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000085.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Düsseldorf",
+         "postalCode" : "40227",
+         "street" : "Konrad-Adenauer-Platz 14"
+      },
+      "distance" : "100-149",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "32",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "400",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 3 days",
+         "tariffNotesEn" : "Attention: Currently less spaces due to construction work.",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 3 Tage",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffNotes" : "Achtung: Zurzeit Einschränkungen wegen Baumaßnahmen.",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 424935,
+         "duration" : "20min"
+      }, {
+         "id" : 424936,
+         "duration" : "30min",
+         "price" : 2.0
+      }, {
+         "id" : 424937,
+         "duration" : "1hour",
+         "price" : 4.0
+      }, {
+         "id" : 424938,
+         "duration" : "1day",
+         "price" : 25.0
+      }, {
+         "id" : 424939,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 424940,
+         "duration" : "1week"
+      }, {
+         "id" : 424941,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 424942,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 424943,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 424944,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100058,
+      "title" : "Düsseldorf Hbf P3 Düsseldorf Hbf P3 Parkhaus",
+      "station" : {
+         "id" : 1401,
+         "name" : "Düsseldorf Hbf"
+      },
+      "label" : "P3",
+      "spaceNumber" : "46",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkhaus Düsseldorf Hauptbahnhof",
+      "nameDisplay" : "Düsseldorf Hbf P3 Parkhaus",
+      "spaceType" : "Parkhaus",
+      "spaceTypeEn" : "Multi storey car park",
+      "spaceTypeName" : "Parkhaus",
+      "geoLocation" : {
+         "longitude" : 6.793619,
+         "latitude" : 51.217563
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000085.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Düsseldorf",
+         "postalCode" : "40227",
+         "street" : "Willi-Becker-Allee/Ludwig-Erhard-Allee"
+      },
+      "distance" : "<50",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "1685",
+      "numberHandicapedPlaces" : "12",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "200",
+         "clearanceHeight" : "200",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "ja"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : true,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : true,
+         "isDiscountDbParkAndRail" : true,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffDiscount" : "Bonierung bei der Parkhausaufsicht, im DB Reisezentrum und an der DB Information. Rabattierung mit BahnCard direkt am Kassenautomaten.",
+         "tariffFreeParkingTime" : "nein",
+         "tariffDiscountEn" : "Reduction from the car park supervisor, at the DB Information and the DB Reisezentrum (travel centre). BahnCard discount available directly at the pay station.",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA, BahnCard-Kreditkarte), EC-Karte, P Card",
+         "tariffPointOfSale" : "Park&Rail-Karten erhältlich an allen Verkaufsstellen der Deutschen Bahn (außer Internet).",
+         "tariffPointOfSaleEn" : "Park&Rail cards available from all Deutsche Bahn points of sale (except online).  ",
+         "tariffPaymentCustomerCards" : "BahnCard, P Card",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA, BahnCard credit card), EC-Card, P Card"
+      },
+      "tariffPrices" : [ {
+         "id" : 219012,
+         "duration" : "20min"
+      }, {
+         "id" : 219013,
+         "duration" : "30min"
+      }, {
+         "id" : 219014,
+         "duration" : "1hour",
+         "price" : 2.4
+      }, {
+         "id" : 219015,
+         "duration" : "1day",
+         "price" : 19.0
+      }, {
+         "id" : 219016,
+         "duration" : "1dayDiscount",
+         "price" : 16.5
+      }, {
+         "id" : 219017,
+         "duration" : "1week"
+      }, {
+         "id" : 219018,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219019,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219020,
+         "duration" : "1monthLongTerm",
+         "price" : 80.0
+      }, {
+         "id" : 219021,
+         "duration" : "1monthReservation",
+         "price" : 100.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100069,
+      "title" : "Eisenach P1 Parkplatz Bahnhof Eisenach",
+      "station" : {
+         "id" : 1528,
+         "name" : "Eisenach"
+      },
+      "label" : "P1",
+      "spaceNumber" : "47",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Eisenach",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 10.332728,
+         "latitude" : 50.975939
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8010097.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Eisenach",
+         "postalCode" : "99817",
+         "street" : "Bahnhofstraße 35 (B19)"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "63",
+      "numberHandicapedPlaces" : "3",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffSpecialEn" : "2 weeks: 35.00",
+         "tariffSpecial" : "2 Wochen: 35,00",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 219062,
+         "duration" : "20min"
+      }, {
+         "id" : 219063,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 219064,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 219065,
+         "duration" : "1day",
+         "price" : 4.4
+      }, {
+         "id" : 219066,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219067,
+         "duration" : "1week",
+         "price" : 22.0
+      }, {
+         "id" : 219068,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219069,
+         "duration" : "1monthVendingMachine",
+         "price" : 60.0
+      }, {
+         "id" : 219070,
+         "duration" : "1monthLongTerm",
+         "price" : 60.0
+      }, {
+         "id" : 219071,
+         "duration" : "1monthReservation",
+         "price" : 120.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100070,
+      "title" : "Elmshorn P1 Parkplatz Bahnhof Elmshorn Kleistraße",
+      "station" : {
+         "id" : 1558,
+         "name" : "Elmshorn"
+      },
+      "label" : "P1",
+      "spaceNumber" : "439",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Kleiststraße",
+      "nameDisplay" : "Parkplatz Bahnhof Elmshorn Kleistraße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.659233,
+         "latitude" : 53.757109
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000092.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Elmshorn",
+         "postalCode" : "25335",
+         "street" : "Kleiststraße 1-15"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "150",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219072,
+         "duration" : "20min"
+      }, {
+         "id" : 219073,
+         "duration" : "30min"
+      }, {
+         "id" : 219074,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 219075,
+         "duration" : "1day",
+         "price" : 2.0
+      }, {
+         "id" : 219076,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219077,
+         "duration" : "1week",
+         "price" : 10.0
+      }, {
+         "id" : 219078,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219079,
+         "duration" : "1monthVendingMachine",
+         "price" : 30.0
+      }, {
+         "id" : 219080,
+         "duration" : "1monthLongTerm",
+         "price" : 30.0
+      }, {
+         "id" : 219081,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100071,
+      "title" : "Elmshorn P2 Parkplatz Bahnhof Elmshorn Schulstraße",
+      "station" : {
+         "id" : 1558,
+         "name" : "Elmshorn"
+      },
+      "label" : "P2",
+      "spaceNumber" : "444",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Schulstraße",
+      "nameDisplay" : "Parkplatz Bahnhof Elmshorn Schulstraße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.658395,
+         "latitude" : 53.75562
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000092.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Elmshorn",
+         "postalCode" : "25335",
+         "street" : "Schulstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "19",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffSpecialEn" : "4 hours: 2.00",
+         "tariffSpecial" : "4 Stunden: 2,00",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Woche",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219082,
+         "duration" : "20min"
+      }, {
+         "id" : 219083,
+         "duration" : "30min"
+      }, {
+         "id" : 219084,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 219085,
+         "duration" : "1day",
+         "price" : 4.5
+      }, {
+         "id" : 219086,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219087,
+         "duration" : "1week",
+         "price" : 22.5
+      }, {
+         "id" : 219088,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219089,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219090,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219091,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100072,
+      "title" : "Erlangen P1 Parkplatz Bahnhof Erlangen Fr.-List-Str.",
+      "station" : {
+         "id" : 1650,
+         "name" : "Erlangen"
+      },
+      "label" : "P1",
+      "spaceNumber" : "48",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Erlangen Fr.-List-Str.",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 11.001674,
+         "latitude" : 49.594404
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8001844.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Erlangen",
+         "postalCode" : "91052",
+         "street" : "Friedrich-List-Straße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "32",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "600",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 219092,
+         "duration" : "20min"
+      }, {
+         "id" : 219093,
+         "duration" : "30min",
+         "price" : 0.8
+      }, {
+         "id" : 219094,
+         "duration" : "1hour",
+         "price" : 1.6
+      }, {
+         "id" : 219095,
+         "duration" : "1day",
+         "price" : 5.0
+      }, {
+         "id" : 219096,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219097,
+         "duration" : "1week",
+         "price" : 20.0
+      }, {
+         "id" : 219098,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219099,
+         "duration" : "1monthVendingMachine",
+         "price" : 50.0
+      }, {
+         "id" : 219100,
+         "duration" : "1monthLongTerm",
+         "price" : 50.0
+      }, {
+         "id" : 219101,
+         "duration" : "1monthReservation",
+         "price" : 80.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100073,
+      "title" : "Essen Hbf P1 Essen Hbf P1 Parkhaus",
+      "station" : {
+         "id" : 1690,
+         "name" : "Essen Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "50",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkhaus Essen Hauptbahnhof",
+      "nameDisplay" : "Essen Hbf P1 Parkhaus",
+      "spaceType" : "Parkhaus",
+      "spaceTypeEn" : "Multi storey car park",
+      "spaceTypeName" : "Parkhaus",
+      "geoLocation" : {
+         "longitude" : 7.015457,
+         "latitude" : 51.450684
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000098.pdf",
+      "operator" : "Contipark International Parking GmbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Essen",
+         "postalCode" : "45127",
+         "street" : "Freiheit 5"
+      },
+      "distance" : "100-149",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "742",
+      "numberHandicapedPlaces" : "1",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "229.99999999999997",
+         "clearanceHeight" : "200",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : true,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : true,
+         "isDiscountDbParkAndRail" : true,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffDiscount" : "Bonierung im DB Reisezentrum und an der DB Information. Rabattierung mit BahnCard direkt am Kassenautomaten.",
+         "tariffFreeParkingTime" : "nein",
+         "tariffDiscountEn" : "Reduction from the DB Information and the DB Reisezentrum (travel centre). BahnCard discount available directly at the pay station.",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA)",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA)"
+      },
+      "tariffPrices" : [ {
+         "id" : 219102,
+         "duration" : "20min"
+      }, {
+         "id" : 219103,
+         "duration" : "30min"
+      }, {
+         "id" : 219104,
+         "duration" : "1hour",
+         "price" : 1.8
+      }, {
+         "id" : 219105,
+         "duration" : "1day",
+         "price" : 16.0
+      }, {
+         "id" : 219106,
+         "duration" : "1dayDiscount",
+         "price" : 14.0
+      }, {
+         "id" : 219107,
+         "duration" : "1week"
+      }, {
+         "id" : 219108,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219109,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219110,
+         "duration" : "1monthLongTerm",
+         "price" : 89.0
+      }, {
+         "id" : 219111,
+         "duration" : "1monthReservation",
+         "price" : 130.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100074,
+      "title" : "Essen Hbf P2 Essen Hbf Vorplatz Nord",
+      "station" : {
+         "id" : 1690,
+         "name" : "Essen Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "49",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Bahnhofsvorplatz Nord",
+      "nameDisplay" : "Essen Hbf Vorplatz Nord",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 7.014919,
+         "latitude" : 51.452121
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000098.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Essen",
+         "postalCode" : "45127",
+         "street" : "Am Hauptbahnhof 5"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "33",
+      "numberHandicapedPlaces" : "1",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 day",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Tag",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219112,
+         "duration" : "20min"
+      }, {
+         "id" : 219113,
+         "duration" : "30min",
+         "price" : 1.2
+      }, {
+         "id" : 219114,
+         "duration" : "1hour",
+         "price" : 2.4
+      }, {
+         "id" : 219115,
+         "duration" : "1day",
+         "price" : 20.0
+      }, {
+         "id" : 219116,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219117,
+         "duration" : "1week"
+      }, {
+         "id" : 219118,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219119,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219120,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219121,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100075,
+      "title" : "Essen Hbf P4 Parkplatz Essen Hbf Hachestraße",
+      "station" : {
+         "id" : 1690,
+         "name" : "Essen Hbf"
+      },
+      "label" : "P4",
+      "spaceNumber" : "404",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Hachestraße",
+      "nameDisplay" : "Parkplatz Essen Hbf Hachestraße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 7.010534,
+         "latitude" : 51.451639
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000098.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Essen",
+         "postalCode" : "45127",
+         "street" : "Hachestraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "26",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 day",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Tag",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219122,
+         "duration" : "20min"
+      }, {
+         "id" : 219123,
+         "duration" : "30min"
+      }, {
+         "id" : 219124,
+         "duration" : "1hour",
+         "price" : 1.5
+      }, {
+         "id" : 219125,
+         "duration" : "1day",
+         "price" : 10.0
+      }, {
+         "id" : 219126,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219127,
+         "duration" : "1week"
+      }, {
+         "id" : 219128,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219129,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219130,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219131,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100076,
+      "title" : "Euskirchen P1 Parkplatz Bahnhof Euskirchen Oststraße",
+      "station" : {
+         "id" : 1734,
+         "name" : "Euskirchen"
+      },
+      "label" : "P1",
+      "spaceNumber" : "361",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Euskirchen Oststraße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 6.793448,
+         "latitude" : 50.658478
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000100.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Euskirchen",
+         "postalCode" : "53879",
+         "street" : "Oststraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "25",
+      "numberHandicapedPlaces" : "1",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 day",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 1 Tag",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 219132,
+         "duration" : "20min"
+      }, {
+         "id" : 219133,
+         "duration" : "30min"
+      }, {
+         "id" : 219134,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 219135,
+         "duration" : "1day",
+         "price" : 10.0
+      }, {
+         "id" : 219136,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219137,
+         "duration" : "1week"
+      }, {
+         "id" : 219138,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219139,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219140,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219141,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100078,
+      "title" : "Forchheim (Oberfr) P1 Parkplatz Forchheim Bahnhofsplatz rechts",
+      "station" : {
+         "id" : 1830,
+         "name" : "Forchheim (Oberfr)"
+      },
+      "label" : "P1",
+      "spaceNumber" : "51",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Forchheim Bahnhofsplatz rechts",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 11.069613,
+         "latitude" : 49.716201
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8002024.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Forchheim in Oberfranken",
+         "postalCode" : "91301",
+         "street" : "Bahnhofsplatz"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "12",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "650",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week from the parking ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 1 Woche am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 219142,
+         "duration" : "20min"
+      }, {
+         "id" : 219143,
+         "duration" : "30min",
+         "price" : 0.5
+      }, {
+         "id" : 219144,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 219145,
+         "duration" : "1day",
+         "price" : 2.2
+      }, {
+         "id" : 219146,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219147,
+         "duration" : "1week",
+         "price" : 8.8
+      }, {
+         "id" : 219148,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219149,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219150,
+         "duration" : "1monthLongTerm",
+         "price" : 35.0
+      }, {
+         "id" : 219151,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100079,
+      "title" : "Frankenthal Hbf P1 Vorplatz Frankenthal Hbf",
+      "station" : {
+         "id" : 1848,
+         "name" : "Frankenthal Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "53",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Vorplatz Frankenthal Hbf",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.350276,
+         "latitude" : 49.535623
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000332.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Frankenthal",
+         "postalCode" : "67228",
+         "street" : "Eisenbahnstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "25",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "350",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Woche",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219152,
+         "duration" : "20min"
+      }, {
+         "id" : 219153,
+         "duration" : "30min",
+         "price" : 0.8
+      }, {
+         "id" : 219154,
+         "duration" : "1hour",
+         "price" : 1.6
+      }, {
+         "id" : 219155,
+         "duration" : "1day",
+         "price" : 6.0
+      }, {
+         "id" : 219156,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219157,
+         "duration" : "1week",
+         "price" : 30.0
+      }, {
+         "id" : 219158,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219159,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219160,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219161,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100080,
+      "title" : "Frankenthal Hbf P2 Parkplatz Frankenthal Hbf rechts",
+      "station" : {
+         "id" : 1848,
+         "name" : "Frankenthal Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "52",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Frankenthal Hbf rechts",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.350094,
+         "latitude" : 49.536659
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000332.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Frankenthal",
+         "postalCode" : "67227",
+         "street" : "Eisenbahnstraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "11",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "1000",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Woche",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219162,
+         "duration" : "20min"
+      }, {
+         "id" : 219163,
+         "duration" : "30min",
+         "price" : 0.7
+      }, {
+         "id" : 219164,
+         "duration" : "1hour",
+         "price" : 1.4
+      }, {
+         "id" : 219165,
+         "duration" : "1day",
+         "price" : 4.0
+      }, {
+         "id" : 219166,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219167,
+         "duration" : "1week",
+         "price" : 16.0
+      }, {
+         "id" : 219168,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219169,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219170,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219171,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100081,
+      "title" : "Frankfurt (Main) Hbf P1 Frankfurt (Main) Hbf P1 Tiefgarage Hbf Nord",
+      "station" : {
+         "id" : 1866,
+         "name" : "Frankfurt (Main) Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "56",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Tiefgarage Hauptbahnhof Nord",
+      "nameDisplay" : "Frankfurt (Main) Hbf P1 Tiefgarage Hbf Nord",
+      "spaceType" : "Tiefgarage",
+      "spaceTypeEn" : "Underground car park",
+      "spaceTypeName" : "Tiefgarage",
+      "geoLocation" : {
+         "longitude" : 8.66191,
+         "latitude" : 50.108074
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000105.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Frankfurt am Main",
+         "postalCode" : "60329",
+         "street" : "Poststraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "365",
+      "numberHandicapedPlaces" : "2",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "reservation" : "www.parkplatz.kaufen",
+      "spaceInfo" : {
+         "clearanceWidth" : "250",
+         "clearanceHeight" : "200",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : true,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : true,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffDiscount" : "Bonierung im DB Reisezentrum. Rabattierung mit BahnCard direkt am Kassenautomaten.",
+         "tariffFreeParkingTime" : "nein",
+         "tariffDiscountEn" : "Reduction from the DB Reisezentrum (travel centre). BahnCard discount available directly at the pay station.",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA, BahnCard-Kreditkarte), EC-Karte, P Card",
+         "tariffPaymentCustomerCards" : "BahnCard, P Card",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA, BahnCard credit card), EC-Card, P Card"
+      },
+      "tariffPrices" : [ {
+         "id" : 219172,
+         "duration" : "20min"
+      }, {
+         "id" : 219173,
+         "duration" : "30min"
+      }, {
+         "id" : 219174,
+         "duration" : "1hour",
+         "price" : 3.0
+      }, {
+         "id" : 219175,
+         "duration" : "1day",
+         "price" : 29.0
+      }, {
+         "id" : 219176,
+         "duration" : "1dayDiscount",
+         "price" : 24.5
+      }, {
+         "id" : 219177,
+         "duration" : "1week"
+      }, {
+         "id" : 219178,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219179,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219180,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219181,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100082,
+      "title" : "Frankfurt (Main) Hbf P2 Frankfurt (Main) Hbf P2 Vorfahrt I",
+      "station" : {
+         "id" : 1866,
+         "name" : "Frankfurt (Main) Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "57",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Hauptbahnhof Vorfahrt I",
+      "nameDisplay" : "Frankfurt (Main) Hbf P2 Vorfahrt I",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.663243,
+         "latitude" : 50.107951
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000105.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Frankfurt am Main",
+         "postalCode" : "60329",
+         "street" : "Poststraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "43",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "330",
+         "clearanceHeight" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : true,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffDiscount" : "Rabattierung mit bahn.comfort-Karte direkt am Kassenautomaten.",
+         "tariffFreeParkingTime" : "nein",
+         "tariffDiscountEn" : "Bahn.comfort card discount available directly at the pay station.",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA), P Card",
+         "tariffPointOfSale" : "Nur mit gültiger bahn.comfort-Karte.",
+         "tariffPointOfSaleEn" : "Only with a valid bahn.comfort card. ",
+         "tariffPaymentCustomerCards" : "P Card",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA), P Card"
+      },
+      "tariffPrices" : [ {
+         "id" : 219182,
+         "duration" : "20min"
+      }, {
+         "id" : 219183,
+         "duration" : "30min",
+         "price" : 2.0
+      }, {
+         "id" : 219184,
+         "duration" : "1hour",
+         "price" : 4.0
+      }, {
+         "id" : 219185,
+         "duration" : "1day",
+         "price" : 29.0
+      }, {
+         "id" : 219186,
+         "duration" : "1dayDiscount",
+         "price" : 24.5
+      }, {
+         "id" : 219187,
+         "duration" : "1week"
+      }, {
+         "id" : 219188,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219189,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219190,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219191,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100083,
+      "title" : "Frankfurt (Main) Hbf P3 Frankfurt (Main) Hbf P3 Vorfahrt II",
+      "station" : {
+         "id" : 1866,
+         "name" : "Frankfurt (Main) Hbf"
+      },
+      "label" : "P3",
+      "spaceNumber" : "58",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Hauptbahnhof Vorfahrt II",
+      "nameDisplay" : "Frankfurt (Main) Hbf P3 Vorfahrt II",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.661147,
+         "latitude" : 50.10758
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000105.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Frankfurt am Main",
+         "postalCode" : "60329",
+         "street" : "Poststraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "18",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "260",
+         "clearanceHeight" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffSpecialEn" : "Each additional 30 minutes: 2.00",
+         "tariffSpecial" : "Je weitere 30 Minuten: 2,00",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA)",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA)"
+      },
+      "tariffPrices" : [ {
+         "id" : 219192,
+         "duration" : "20min"
+      }, {
+         "id" : 219193,
+         "duration" : "30min"
+      }, {
+         "id" : 219194,
+         "duration" : "1hour",
+         "price" : 4.0
+      }, {
+         "id" : 219195,
+         "duration" : "1day"
+      }, {
+         "id" : 219196,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219197,
+         "duration" : "1week"
+      }, {
+         "id" : 219198,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219199,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219200,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219201,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100084,
+      "title" : "Frankfurt (Main) Hbf P4 Frankfurt (Main) Hbf Bustasche",
+      "station" : {
+         "id" : 1866,
+         "name" : "Frankfurt (Main) Hbf"
+      },
+      "label" : "P4",
+      "spaceNumber" : "55",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Hbf Bustasche/Südtasche",
+      "nameDisplay" : "Frankfurt (Main) Hbf Bustasche",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.66479,
+         "latitude" : 50.107129
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000105.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Frankfurt am Main",
+         "postalCode" : "60329",
+         "street" : "Am Hauptbahnhof"
+      },
+      "distance" : "<50",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "50",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "450",
+         "clearanceHeight" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "ja"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA), P Card",
+         "tariffPaymentCustomerCards" : "P Card",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA), P Card"
+      },
+      "tariffPrices" : [ {
+         "id" : 219202,
+         "duration" : "20min"
+      }, {
+         "id" : 219203,
+         "duration" : "30min",
+         "price" : 2.0
+      }, {
+         "id" : 219204,
+         "duration" : "1hour",
+         "price" : 4.0
+      }, {
+         "id" : 219205,
+         "duration" : "1day"
+      }, {
+         "id" : 219206,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219207,
+         "duration" : "1week"
+      }, {
+         "id" : 219208,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219209,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219210,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219211,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100085,
+      "title" : "Frankfurt (Main) Hbf P5 Frankfurt (Main) Hbf Parkplatz Gleis 26",
+      "station" : {
+         "id" : 1866,
+         "name" : "Frankfurt (Main) Hbf"
+      },
+      "label" : "P5",
+      "spaceNumber" : "263",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Hbf am Gleis",
+      "nameDisplay" : "Frankfurt (Main) Hbf Parkplatz Gleis 26",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.660092,
+         "latitude" : 50.107071
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000105.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Frankfurt am Main",
+         "postalCode" : "63029",
+         "street" : "Poststraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "45",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "450",
+         "clearanceHeight" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 10 days",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 10 Tage",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219212,
+         "duration" : "20min"
+      }, {
+         "id" : 219213,
+         "duration" : "30min"
+      }, {
+         "id" : 219214,
+         "duration" : "1hour",
+         "price" : 3.0
+      }, {
+         "id" : 219215,
+         "duration" : "1day",
+         "price" : 29.0
+      }, {
+         "id" : 219216,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219217,
+         "duration" : "1week"
+      }, {
+         "id" : 219218,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219219,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219220,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219221,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100086,
+      "title" : "Frankfurt (Main) West P1 Parkplatz Bahnhof Frankfurt (Main) West",
+      "station" : {
+         "id" : 1858,
+         "name" : "Frankfurt (Main) West"
+      },
+      "label" : "P1",
+      "spaceNumber" : "245",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Frankfurt (Main) West",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.639006,
+         "latitude" : 50.119698
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8002042.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Frankfurt am Main",
+         "postalCode" : "60486",
+         "street" : "Kasseler Straße"
+      },
+      "distance" : "100-149",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "90",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "clearanceHeight" : "300",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219222,
+         "duration" : "20min"
+      }, {
+         "id" : 219223,
+         "duration" : "30min"
+      }, {
+         "id" : 219224,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 219225,
+         "duration" : "1day",
+         "price" : 4.6
+      }, {
+         "id" : 219226,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219227,
+         "duration" : "1week",
+         "price" : 23.0
+      }, {
+         "id" : 219228,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219229,
+         "duration" : "1monthVendingMachine",
+         "price" : 52.0
+      }, {
+         "id" : 219230,
+         "duration" : "1monthLongTerm",
+         "price" : 52.0
+      }, {
+         "id" : 219231,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100087,
+      "title" : "Frankfurt-Höchst P1 Parkplatz Bahnhof Höchst Dalbergstraße",
+      "station" : {
+         "id" : 1872,
+         "name" : "Frankfurt-Höchst"
+      },
+      "label" : "P1",
+      "spaceNumber" : "59",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Höchst Dalbergstraße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.543826,
+         "latitude" : 50.102158
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000106.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Frankfurt am Main",
+         "postalCode" : "65929",
+         "street" : "Dalbergstraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "43",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "clearanceHeight" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week from the parking ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Woche am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219232,
+         "duration" : "20min"
+      }, {
+         "id" : 219233,
+         "duration" : "30min",
+         "price" : 1.0
+      }, {
+         "id" : 219234,
+         "duration" : "1hour",
+         "price" : 2.0
+      }, {
+         "id" : 219235,
+         "duration" : "1day",
+         "price" : 4.8
+      }, {
+         "id" : 219236,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219237,
+         "duration" : "1week",
+         "price" : 24.0
+      }, {
+         "id" : 219238,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219239,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219240,
+         "duration" : "1monthLongTerm",
+         "price" : 80.0
+      }, {
+         "id" : 219241,
+         "duration" : "1monthReservation",
+         "price" : 130.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100088,
+      "title" : "Frankfurt-Höchst Farbwerke P1 Parkplatz Bahnhof Höchst Farbwerke",
+      "station" : {
+         "id" : 1763,
+         "name" : "Frankfurt-Höchst Farbwerke"
+      },
+      "label" : "P1",
+      "spaceNumber" : "422",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Höchst Farbwerke",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.527036,
+         "latitude" : 50.097678
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8002051.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Frankfurt am Main",
+         "postalCode" : "65931",
+         "street" : "Hoechster-Farben-Straße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "82",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 3 days from the parking ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffSpecialEn" : "Limited season parking availabilty.",
+         "tariffSpecial" : "Begrenzte Verfügbarkeit Dauerparken",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 3 Tage am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 743518,
+         "duration" : "20min"
+      }, {
+         "id" : 743519,
+         "duration" : "30min"
+      }, {
+         "id" : 743520,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 743521,
+         "duration" : "1day",
+         "price" : 3.0
+      }, {
+         "id" : 743522,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 743523,
+         "duration" : "1week"
+      }, {
+         "id" : 743524,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 743525,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 743526,
+         "duration" : "1monthLongTerm",
+         "price" : 50.0
+      }, {
+         "id" : 743527,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100089,
+      "title" : "Freiberg (Sachs) P1 Vorplatz Bahnhof Freiberg (Sachs)",
+      "station" : {
+         "id" : 1891,
+         "name" : "Freiberg (Sachs)"
+      },
+      "label" : "P1",
+      "spaceNumber" : "60",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Vorplatz Bahnhof Freiberg (Sachs)",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 13.344013,
+         "latitude" : 50.909162
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8010115.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Freiberg in Sachsen",
+         "postalCode" : "09599",
+         "street" : "Am Bahnhof"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "65",
+      "numberHandicapedPlaces" : "2",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219252,
+         "duration" : "20min"
+      }, {
+         "id" : 219253,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 219254,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 219255,
+         "duration" : "1day",
+         "price" : 1.7
+      }, {
+         "id" : 219256,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219257,
+         "duration" : "1week",
+         "price" : 6.8
+      }, {
+         "id" : 219258,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219259,
+         "duration" : "1monthVendingMachine",
+         "price" : 25.0
+      }, {
+         "id" : 219260,
+         "duration" : "1monthLongTerm",
+         "price" : 25.0
+      }, {
+         "id" : 219261,
+         "duration" : "1monthReservation",
+         "price" : 50.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100090,
+      "title" : "Freiburg (Breisgau) Hbf P1 Freiburg (Breisgau) Hbf P1 Tiefgarage am Bahnhof",
+      "station" : {
+         "id" : 1893,
+         "name" : "Freiburg (Breisgau) Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "346",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Tiefgarage am Bahnhof",
+      "nameDisplay" : "Freiburg (Breisgau) Hbf P1 Tiefgarage am Bahnhof",
+      "spaceType" : "Tiefgarage",
+      "spaceTypeEn" : "Underground car park",
+      "spaceTypeName" : "Tiefgarage",
+      "geoLocation" : {
+         "longitude" : 7.843281,
+         "latitude" : 47.998862
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000107.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Freiburg im Breisgau",
+         "postalCode" : "79098",
+         "street" : "Bismarckallee"
+      },
+      "distance" : "<50",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "05:30 - 01:00 Uhr. Ausfahrt jederzeit möglich.",
+      "openingHoursEn" : "5:30am - 1:00am, exit possible at any time.  ",
+      "numberParkingPlaces" : "278",
+      "numberHandicapedPlaces" : "10",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "276",
+         "clearanceHeight" : "265",
+         "locationNightAccess" : "Über Türleser Hauseingang 7f",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : true,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : true,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffSpecialEn" : "2nd and futher hours will be calculated per hour.",
+         "tariffPointOfSaleEn" : "Park&Rail cards available from DB points of sale.",
+         "tarifNotesEn" : "Parking directly by the platform. ",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffNotes" : "Parken direkt am Gleis.",
+         "tariffDiscount" : "Rabattierung mit BahnCard direkt am Kassenautomaten. Bonierung an der DB Information (06:00 bis 24:00 Uhr).",
+         "tariffFreeParkingTime" : "nein",
+         "tariffSpecial" : "Stundentakt ab der zweiten Parkstunde.",
+         "tariffDiscountEn" : "BahnCard discount available directly at the pay station. Reduction from the DB Information (opening hours from 6am to 12midnight).  ",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA), EC-Karte",
+         "tariffPointOfSale" : "Park&Rail-Karten erhältlich an DB-Verkaufsstellen.",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA), EC-Card"
+      },
+      "tariffPrices" : [ {
+         "id" : 219272,
+         "duration" : "20min",
+         "price" : 0.5
+      }, {
+         "id" : 219273,
+         "duration" : "30min"
+      }, {
+         "id" : 219274,
+         "duration" : "1hour",
+         "price" : 2.0
+      }, {
+         "id" : 219275,
+         "duration" : "1day",
+         "price" : 16.0
+      }, {
+         "id" : 219276,
+         "duration" : "1dayDiscount",
+         "price" : 9.9
+      }, {
+         "id" : 219277,
+         "duration" : "1week"
+      }, {
+         "id" : 219278,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219279,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219280,
+         "duration" : "1monthLongTerm",
+         "price" : 175.0
+      }, {
+         "id" : 219281,
+         "duration" : "1monthReservation",
+         "price" : 230.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100091,
+      "title" : "Freiburg (Breisgau) Hbf P2 Parkplatz Freiburg Hbf Wentzingerstraße",
+      "station" : {
+         "id" : 1893,
+         "name" : "Freiburg (Breisgau) Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "61",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Wentzingerstraße",
+      "nameDisplay" : "Parkplatz Freiburg Hbf Wentzingerstraße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 7.839455,
+         "latitude" : 47.996924
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000107.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Freiburg im Breisgau",
+         "postalCode" : "79106",
+         "street" : "Wentzingerstraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "125",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "550",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : true,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks from the parking ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffPointOfSale" : "Park&Rail-Karten erhältlich an DB-Verkaufsstellen.",
+         "tariffPointOfSaleEn" : "Park&Rail cards available from DB points of sale.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219262,
+         "duration" : "20min"
+      }, {
+         "id" : 219263,
+         "duration" : "30min"
+      }, {
+         "id" : 219264,
+         "duration" : "1hour",
+         "price" : 1.8
+      }, {
+         "id" : 219265,
+         "duration" : "1day",
+         "price" : 7.5
+      }, {
+         "id" : 219266,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219267,
+         "duration" : "1week",
+         "price" : 37.5
+      }, {
+         "id" : 219268,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219269,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219270,
+         "duration" : "1monthLongTerm",
+         "price" : 120.0
+      }, {
+         "id" : 219271,
+         "duration" : "1monthReservation",
+         "price" : 160.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100093,
+      "title" : "Friedberg (Hess) P1 Parkplatz Bahnhof Friedberg Vorfahrt",
+      "station" : {
+         "id" : 1930,
+         "name" : "Friedberg (Hess)"
+      },
+      "label" : "P1",
+      "spaceNumber" : "63",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Friedberg Vorfahrt",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.760571,
+         "latitude" : 50.332411
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000111.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Friedberg in Hessen",
+         "postalCode" : "61169",
+         "street" : "Hanauer Straße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "10",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "clearanceHeight" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 3 days",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 3 Tage",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 219282,
+         "duration" : "20min"
+      }, {
+         "id" : 219283,
+         "duration" : "30min"
+      }, {
+         "id" : 219284,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 219285,
+         "duration" : "1day",
+         "price" : 5.7
+      }, {
+         "id" : 219286,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219287,
+         "duration" : "1week"
+      }, {
+         "id" : 219288,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219289,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219290,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219291,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100094,
+      "title" : "Friedberg (Hess) P2 Parkplatz Bahnhof Friedberg links",
+      "station" : {
+         "id" : 1930,
+         "name" : "Friedberg (Hess)"
+      },
+      "label" : "P2",
+      "spaceNumber" : "64",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Friedberg links",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.76013,
+         "latitude" : 50.333159
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000111.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Friedberg in Hessen",
+         "postalCode" : "61169",
+         "street" : "Hanauer Straße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "72",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "clearanceHeight" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week from the parking ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 1 Woche am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 743508,
+         "duration" : "20min"
+      }, {
+         "id" : 743509,
+         "duration" : "30min"
+      }, {
+         "id" : 743510,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 743511,
+         "duration" : "1day",
+         "price" : 5.7
+      }, {
+         "id" : 743512,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 743513,
+         "duration" : "1week",
+         "price" : 28.5
+      }, {
+         "id" : 743514,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 743515,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 743516,
+         "duration" : "1monthLongTerm",
+         "price" : 60.0
+      }, {
+         "id" : 743517,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100095,
+      "title" : "Friedberg (Hess) P3 Parkplatz Bahnhof Friedberg rechts",
+      "station" : {
+         "id" : 1930,
+         "name" : "Friedberg (Hess)"
+      },
+      "label" : "P3",
+      "spaceNumber" : "62",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Friedberg rechts",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.761081,
+         "latitude" : 50.331373
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000111.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Friedberg in Hessen",
+         "postalCode" : "61169",
+         "street" : "Hanauer Straße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "25",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "clearanceHeight" : "200",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week from the parking ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 1 Woche am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 219302,
+         "duration" : "20min"
+      }, {
+         "id" : 219303,
+         "duration" : "30min"
+      }, {
+         "id" : 219304,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 219305,
+         "duration" : "1day",
+         "price" : 5.7
+      }, {
+         "id" : 219306,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219307,
+         "duration" : "1week",
+         "price" : 28.5
+      }, {
+         "id" : 219308,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219309,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219310,
+         "duration" : "1monthLongTerm",
+         "price" : 60.0
+      }, {
+         "id" : 219311,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100096,
+      "title" : "Fulda P1 Parkplatz Bahnhof Fulda links",
+      "station" : {
+         "id" : 1973,
+         "name" : "Fulda"
+      },
+      "label" : "P1",
+      "spaceNumber" : "65",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Fulda links",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.683199,
+         "latitude" : 50.554729
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000115.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Fulda",
+         "postalCode" : "36037",
+         "street" : "Kurfürstenstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "15",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "500",
+         "clearanceHeight" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Woche",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219312,
+         "duration" : "20min"
+      }, {
+         "id" : 219313,
+         "duration" : "30min",
+         "price" : 1.0
+      }, {
+         "id" : 219314,
+         "duration" : "1hour",
+         "price" : 2.0
+      }, {
+         "id" : 219315,
+         "duration" : "1day",
+         "price" : 10.0
+      }, {
+         "id" : 219316,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219317,
+         "duration" : "1week",
+         "price" : 50.0
+      }, {
+         "id" : 219318,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219319,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219320,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219321,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100097,
+      "title" : "Fulda P2 Parkplatz Bahnhof Fulda rechts",
+      "station" : {
+         "id" : 1973,
+         "name" : "Fulda"
+      },
+      "label" : "P2",
+      "spaceNumber" : "66",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Fulda rechts",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.684362,
+         "latitude" : 50.554043
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000115.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Fulda",
+         "postalCode" : "36037",
+         "street" : "Am Bahnhof"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "15",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Woche",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219322,
+         "duration" : "20min"
+      }, {
+         "id" : 219323,
+         "duration" : "30min",
+         "price" : 1.0
+      }, {
+         "id" : 219324,
+         "duration" : "1hour",
+         "price" : 2.0
+      }, {
+         "id" : 219325,
+         "duration" : "1day",
+         "price" : 10.0
+      }, {
+         "id" : 219326,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219327,
+         "duration" : "1week",
+         "price" : 50.0
+      }, {
+         "id" : 219328,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219329,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219330,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219331,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100098,
+      "title" : "Fulda P3 Parkplatz Bahnhof Fulda Viehrampe",
+      "station" : {
+         "id" : 1973,
+         "name" : "Fulda"
+      },
+      "label" : "P3",
+      "spaceNumber" : "259",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Fulda Viehrampe",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.682424,
+         "latitude" : 50.555205
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000115.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Fulda",
+         "postalCode" : "36037",
+         "street" : "Kurfürstenstraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "keine",
+      "facilityTypeEn" : "none",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "45",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "390",
+         "clearanceHeight" : "320",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffFreeParkingTimeEn" : "nein"
+      },
+      "tariffPrices" : [ {
+         "id" : 219332,
+         "duration" : "20min"
+      }, {
+         "id" : 219333,
+         "duration" : "30min"
+      }, {
+         "id" : 219334,
+         "duration" : "1hour"
+      }, {
+         "id" : 219335,
+         "duration" : "1day"
+      }, {
+         "id" : 219336,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219337,
+         "duration" : "1week"
+      }, {
+         "id" : 219338,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219339,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219340,
+         "duration" : "1monthLongTerm",
+         "price" : 60.0
+      }, {
+         "id" : 219341,
+         "duration" : "1monthReservation",
+         "price" : 80.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100077,
+      "title" : "Fürstenfeldbruck P1 Parkplatz Bahnhof Fürstenfeldbruck",
+      "station" : {
+         "id" : 1977,
+         "name" : "Fürstenfeldbruck"
+      },
+      "label" : "P1",
+      "spaceNumber" : "409",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Fürstenfeldbruck",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 11.261719,
+         "latitude" : 48.172913
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8002141.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Fürstenfeldbruck",
+         "postalCode" : "82256",
+         "street" : "Oskar-von-Miller-Straße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "400",
+      "numberHandicapedPlaces" : "3",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 10 days or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 10 Tage oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219342,
+         "duration" : "20min"
+      }, {
+         "id" : 219343,
+         "duration" : "30min"
+      }, {
+         "id" : 219344,
+         "duration" : "1hour",
+         "price" : 0.5
+      }, {
+         "id" : 219345,
+         "duration" : "1day",
+         "price" : 1.2
+      }, {
+         "id" : 219346,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219347,
+         "duration" : "1week",
+         "price" : 6.0
+      }, {
+         "id" : 219348,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219349,
+         "duration" : "1monthVendingMachine",
+         "price" : 10.0
+      }, {
+         "id" : 219350,
+         "duration" : "1monthLongTerm",
+         "price" : 10.0
+      }, {
+         "id" : 219351,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100099,
+      "title" : "Garmisch-Partenkirchen P1 Parkplatz Bahnhof Garmisch-Partenkirchen",
+      "station" : {
+         "id" : 2014,
+         "name" : "Garmisch-Partenkirchen"
+      },
+      "label" : "P1",
+      "spaceNumber" : "310",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Garmisch-Partenkirchen",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 11.098251,
+         "latitude" : 47.491699
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8002187.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Garmisch-Partenkirchen",
+         "postalCode" : "82467",
+         "street" : "Bahnhofstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "87",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 9 days or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 9 Tage oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219352,
+         "duration" : "20min"
+      }, {
+         "id" : 219353,
+         "duration" : "30min"
+      }, {
+         "id" : 219354,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 219355,
+         "duration" : "1day",
+         "price" : 4.6
+      }, {
+         "id" : 219356,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219357,
+         "duration" : "1week",
+         "price" : 23.0
+      }, {
+         "id" : 219358,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219359,
+         "duration" : "1monthVendingMachine",
+         "price" : 35.0
+      }, {
+         "id" : 219360,
+         "duration" : "1monthLongTerm",
+         "price" : 35.0
+      }, {
+         "id" : 219361,
+         "duration" : "1monthReservation",
+         "price" : 50.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100104,
+      "title" : "Geislingen (Steige) P1 Parkplatz Bahnhof Geislingen",
+      "station" : {
+         "id" : 2045,
+         "name" : "Geislingen (Steige)"
+      },
+      "label" : "P1",
+      "spaceNumber" : "69",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Geislingen",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.841341,
+         "latitude" : 48.619083
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8002218.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Geislingen an der Steige",
+         "postalCode" : "73312",
+         "street" : "Bahnhofstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "50",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "600",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 219362,
+         "duration" : "20min"
+      }, {
+         "id" : 219363,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 219364,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 219365,
+         "duration" : "1day",
+         "price" : 4.4
+      }, {
+         "id" : 219366,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219367,
+         "duration" : "1week",
+         "price" : 17.6
+      }, {
+         "id" : 219368,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219369,
+         "duration" : "1monthVendingMachine",
+         "price" : 38.0
+      }, {
+         "id" : 219370,
+         "duration" : "1monthLongTerm",
+         "price" : 38.0
+      }, {
+         "id" : 219371,
+         "duration" : "1monthReservation",
+         "price" : 50.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100105,
+      "title" : "Geislingen (Steige) P3 Parkplatz Bahnhof Geislingen Katzenloch",
+      "station" : {
+         "id" : 2045,
+         "name" : "Geislingen (Steige)"
+      },
+      "label" : "P3",
+      "spaceNumber" : "70",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Geislingen Katzenloch",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.843577,
+         "latitude" : 48.62103
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8002218.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Geislingen an der Steige",
+         "postalCode" : "73312",
+         "street" : "Weilerstraße"
+      },
+      "distance" : "200-250",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "48",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "600",
+         "clearanceHeight" : "600",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 219372,
+         "duration" : "20min"
+      }, {
+         "id" : 219373,
+         "duration" : "30min"
+      }, {
+         "id" : 219374,
+         "duration" : "1hour"
+      }, {
+         "id" : 219375,
+         "duration" : "1day",
+         "price" : 2.5
+      }, {
+         "id" : 219376,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219377,
+         "duration" : "1week",
+         "price" : 10.0
+      }, {
+         "id" : 219378,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219379,
+         "duration" : "1monthVendingMachine",
+         "price" : 22.0
+      }, {
+         "id" : 219380,
+         "duration" : "1monthLongTerm",
+         "price" : 22.0
+      }, {
+         "id" : 219381,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100106,
+      "title" : "Gelnhausen P1 Parkplatz Bahnhof Gelnhausen",
+      "station" : {
+         "id" : 2051,
+         "name" : "Gelnhausen"
+      },
+      "label" : "P1",
+      "spaceNumber" : "71",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Gelnhausen",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.19027,
+         "latitude" : 50.196063
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000117.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Gelnhausen",
+         "postalCode" : "63589",
+         "street" : "Lagerhausstraße"
+      },
+      "distance" : "100-149",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "170",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "clearanceHeight" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219382,
+         "duration" : "20min"
+      }, {
+         "id" : 219383,
+         "duration" : "30min",
+         "price" : 0.5
+      }, {
+         "id" : 219384,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 219385,
+         "duration" : "1day",
+         "price" : 3.2
+      }, {
+         "id" : 219386,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219387,
+         "duration" : "1week",
+         "price" : 16.0
+      }, {
+         "id" : 219388,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219389,
+         "duration" : "1monthVendingMachine",
+         "price" : 35.0
+      }, {
+         "id" : 219390,
+         "duration" : "1monthLongTerm",
+         "price" : 35.0
+      }, {
+         "id" : 219391,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100107,
+      "title" : "Gelnhausen P2 Parkhaus Bahnhof Gelnhausen",
+      "station" : {
+         "id" : 2051,
+         "name" : "Gelnhausen"
+      },
+      "label" : "P2",
+      "spaceNumber" : "294",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkhaus Bahnhof Gelnhausen",
+      "spaceType" : "Parkhaus",
+      "spaceTypeEn" : "Multi storey car park",
+      "spaceTypeName" : "Parkhaus",
+      "geoLocation" : {
+         "longitude" : 9.190164,
+         "latitude" : 50.196849
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000117.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Gelnhausen",
+         "postalCode" : "63571",
+         "street" : "Bahnhofstraße 8"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "321",
+      "numberHandicapedPlaces" : "1",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "270",
+         "clearanceHeight" : "235",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tarifNotesEn" : "for satnav users: Attention. Same address at the station Hailer-Meerholz (at Gelnhausen aswell).",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffNotes" : "für Navinutzer: Achtung. Gleiche Adresse am Bahnhof Hailer-Meerholz (ebenfalls Gelnhausen).",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219392,
+         "duration" : "20min"
+      }, {
+         "id" : 219393,
+         "duration" : "30min",
+         "price" : 0.5
+      }, {
+         "id" : 219394,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 219395,
+         "duration" : "1day",
+         "price" : 2.9
+      }, {
+         "id" : 219396,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219397,
+         "duration" : "1week",
+         "price" : 14.5
+      }, {
+         "id" : 219398,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219399,
+         "duration" : "1monthVendingMachine",
+         "price" : 32.0
+      }, {
+         "id" : 219400,
+         "duration" : "1monthLongTerm",
+         "price" : 32.0
+      }, {
+         "id" : 219401,
+         "duration" : "1monthReservation",
+         "price" : 45.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100108,
+      "title" : "Gemünden (Main) P1 Parkplatz Bahnhof Gemünden",
+      "station" : {
+         "id" : 2060,
+         "name" : "Gemünden (Main)"
+      },
+      "label" : "P1",
+      "spaceNumber" : "73",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Gemünden",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.701151,
+         "latitude" : 50.049604
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000120.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Gemünden am Main",
+         "postalCode" : "97737",
+         "street" : "Bahnhofstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "23",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "clearanceHeight" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week from the parking ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 1 Woche am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 219402,
+         "duration" : "20min"
+      }, {
+         "id" : 219403,
+         "duration" : "30min",
+         "price" : 0.5
+      }, {
+         "id" : 219404,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 219405,
+         "duration" : "1day",
+         "price" : 2.5
+      }, {
+         "id" : 219406,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219407,
+         "duration" : "1week",
+         "price" : 10.0
+      }, {
+         "id" : 219408,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219409,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219410,
+         "duration" : "1monthLongTerm",
+         "price" : 20.0
+      }, {
+         "id" : 219411,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100109,
+      "title" : "Gera Hbf P1 Parkplatz Gera Hbf",
+      "station" : {
+         "id" : 2073,
+         "name" : "Gera Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "74",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Gera Hbf",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 12.078861,
+         "latitude" : 50.884647
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8010125.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Gera",
+         "postalCode" : "07545",
+         "street" : "Bahnhofstraße/Franz-Mehring-Straße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "130",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 11 days or four-weeks-ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffSpecialEn" : "4 weeks ticket (28 days): 28.00",
+         "tariffSpecial" : "4-Wochen-Parkschein (28 Tage): 28,00",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 11 Tage oder 4-Wochen-Parkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219412,
+         "duration" : "20min"
+      }, {
+         "id" : 219413,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 219414,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 219415,
+         "duration" : "1day",
+         "price" : 3.0
+      }, {
+         "id" : 219416,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219417,
+         "duration" : "1week",
+         "price" : 15.0
+      }, {
+         "id" : 219418,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219419,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219420,
+         "duration" : "1monthLongTerm",
+         "price" : 40.0
+      }, {
+         "id" : 219421,
+         "duration" : "1monthReservation",
+         "price" : 50.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100110,
+      "title" : "Gera Süd P1 Parkplatz Bahnhof Gera Süd",
+      "station" : {
+         "id" : 2075,
+         "name" : "Gera Süd"
+      },
+      "label" : "P1",
+      "spaceNumber" : "254",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Gera Süd",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 12.079624,
+         "latitude" : 50.869704
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8010126.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Gera",
+         "postalCode" : "07545",
+         "street" : "Sachsenplatz/Erfurtstraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "75",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 30 days",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 30 Tage",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219422,
+         "duration" : "20min"
+      }, {
+         "id" : 219423,
+         "duration" : "30min"
+      }, {
+         "id" : 219424,
+         "duration" : "1hour"
+      }, {
+         "id" : 219425,
+         "duration" : "1day",
+         "price" : 1.0
+      }, {
+         "id" : 219426,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219427,
+         "duration" : "1week",
+         "price" : 7.0
+      }, {
+         "id" : 219428,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219429,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219430,
+         "duration" : "1monthLongTerm",
+         "price" : 18.0
+      }, {
+         "id" : 219431,
+         "duration" : "1monthReservation",
+         "price" : 30.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100111,
+      "title" : "Gießen P1 Gießen P1 Parkhaus am Bahnhof",
+      "station" : {
+         "id" : 2120,
+         "name" : "Gießen"
+      },
+      "label" : "P1",
+      "spaceNumber" : "363",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkhaus am Bahnhof",
+      "nameDisplay" : "Gießen P1 Parkhaus am Bahnhof",
+      "spaceType" : "Parkhaus",
+      "spaceTypeEn" : "Multi storey car park",
+      "spaceTypeName" : "Parkhaus",
+      "geoLocation" : {
+         "longitude" : 8.664808,
+         "latitude" : 50.580272
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000124.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Gießen",
+         "postalCode" : "35390",
+         "street" : "Bahnhofstraße / An der alten Post"
+      },
+      "distance" : "150-199",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "247",
+      "numberHandicapedPlaces" : "10",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "280",
+         "clearanceHeight" : "204.99999999999997",
+         "locationNightAccess" : "Rechts neben der Auffahrt ",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : true,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffDiscount" : "Rabattierung mit BahnCard direkt am Kassenautomaten.",
+         "tariffFreeParkingTime" : "nein",
+         "tariffSpecialEn" : "1 day with P Card: 3.50",
+         "tariffSpecial" : "1 Tag mit P Card: 3,50",
+         "tariffDiscountEn" : "BahnCard discount available directly at the pay station.",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA, BahnCard-Kreditkarte), EC-Karte, P Card",
+         "tariffPaymentCustomerCards" : "BahnCard, P Card",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA, BahnCard credit card), EC-Card, P Card"
+      },
+      "tariffPrices" : [ {
+         "id" : 233186,
+         "duration" : "20min"
+      }, {
+         "id" : 233187,
+         "duration" : "30min"
+      }, {
+         "id" : 233188,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 233189,
+         "duration" : "1day",
+         "price" : 4.0
+      }, {
+         "id" : 233190,
+         "duration" : "1dayDiscount",
+         "price" : 3.5
+      }, {
+         "id" : 233191,
+         "duration" : "1week"
+      }, {
+         "id" : 233192,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 233193,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 233194,
+         "duration" : "1monthLongTerm",
+         "price" : 70.0
+      }, {
+         "id" : 233195,
+         "duration" : "1monthReservation",
+         "price" : 100.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100100,
+      "title" : "Göppingen P1 Parkplatz Bahnhof Göppingen Kanalstraße",
+      "station" : {
+         "id" : 2189,
+         "name" : "Göppingen"
+      },
+      "label" : "P1",
+      "spaceNumber" : "77",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Göppingen Kanalstraße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.651294,
+         "latitude" : 48.700641
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000127.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Göppingen",
+         "postalCode" : "73033",
+         "street" : "Kanalstraße",
+         "supplement" : "über Kellereistraße",
+         "supplementEn" : "via Kellereistraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "25",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 3 days",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 3 Tage",
+         "tarifNotesEn" : "ATTENTION: Less parking scaces due to contruction work.",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffNotes" : "",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 424955,
+         "duration" : "20min"
+      }, {
+         "id" : 424956,
+         "duration" : "30min",
+         "price" : 0.7
+      }, {
+         "id" : 424957,
+         "duration" : "1hour",
+         "price" : 1.4
+      }, {
+         "id" : 424958,
+         "duration" : "1day",
+         "price" : 6.0
+      }, {
+         "id" : 424959,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 424960,
+         "duration" : "1week"
+      }, {
+         "id" : 424961,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 424962,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 424963,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 424964,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100101,
+      "title" : "Göppingen P2 Parkplatz Bahnhof Göppingen Davidstraße",
+      "station" : {
+         "id" : 2189,
+         "name" : "Göppingen"
+      },
+      "label" : "P2",
+      "spaceNumber" : "76",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Göppingen Davidstraße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.65384,
+         "latitude" : 48.699943
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000127.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Göppingen",
+         "postalCode" : "73033",
+         "street" : "Schützenstraße/Davidstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "55",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 3 days",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 3 Tage",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 424945,
+         "duration" : "20min"
+      }, {
+         "id" : 424946,
+         "duration" : "30min",
+         "price" : 0.7
+      }, {
+         "id" : 424947,
+         "duration" : "1hour",
+         "price" : 1.4
+      }, {
+         "id" : 424948,
+         "duration" : "1day",
+         "price" : 6.0
+      }, {
+         "id" : 424949,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 424950,
+         "duration" : "1week"
+      }, {
+         "id" : 424951,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 424952,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 424953,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 424954,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100102,
+      "title" : "Göttingen P1 Göttingen P1 Parkplatz",
+      "station" : {
+         "id" : 2218,
+         "name" : "Göttingen"
+      },
+      "label" : "P1",
+      "spaceNumber" : "447",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Göttingen P1 Parkplatz",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.924174,
+         "latitude" : 51.535905
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000128.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Göttingen",
+         "postalCode" : "37081",
+         "street" : "Bahnhofsallee 2"
+      },
+      "distance" : "<50",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "107",
+      "numberHandicapedPlaces" : "6",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : true,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : true,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffDiscount" : "Rabattierung mit BahnCard direkt am Kassenautomaten. Bonierung an der DB Information. Bitte beachten Sie die Öffnungszeiten der DB Information.",
+         "tariffFreeParkingTime" : "nein",
+         "tariffSpecialEn" : "2nd and futher hours will be calculated per hour. 2nd and additional weeks: max. 30.00. Event tariff (available 4pm till 9pm, valid 4pm till 3am): 6.00",
+         "tariffSpecial" : "Stundentakt ab der zweiten Parkstunde. 2. und weitere Wochen: max. 30,00. Veranstaltungstarif, erhältlich von 16:00 bis 21:00 Uhr (gültig 16:00 bis 03:00 Uhr): 6,00.",
+         "tariffDiscountEn" : "BahnCard discount available directly at the pay station. Reduction from the DB Information. Please note the DB Information's opening hours. ",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA), EC-Karte",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA), EC-Card"
+      },
+      "tariffPrices" : [ {
+         "id" : 219462,
+         "duration" : "20min"
+      }, {
+         "id" : 219463,
+         "duration" : "30min",
+         "price" : 0.7
+      }, {
+         "id" : 219464,
+         "duration" : "1hour",
+         "price" : 1.7
+      }, {
+         "id" : 219465,
+         "duration" : "1day",
+         "price" : 13.0
+      }, {
+         "id" : 219466,
+         "duration" : "1dayDiscount",
+         "price" : 9.0
+      }, {
+         "id" : 219467,
+         "duration" : "1week",
+         "price" : 40.0
+      }, {
+         "id" : 219468,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219469,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219470,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219471,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100103,
+      "title" : "Göttingen P2 Göttingen P2 Parkhaus",
+      "station" : {
+         "id" : 2218,
+         "name" : "Göttingen"
+      },
+      "label" : "P2",
+      "spaceNumber" : "448",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkhaus am Bahnhof",
+      "nameDisplay" : "Göttingen P2 Parkhaus",
+      "spaceType" : "Parkhaus",
+      "spaceTypeEn" : "Multi storey car park",
+      "spaceTypeName" : "Parkhaus",
+      "geoLocation" : {
+         "longitude" : 9.923472,
+         "latitude" : 51.53533
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000128.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Göttingen",
+         "postalCode" : "37081",
+         "street" : "Bahnhofsallee 2"
+      },
+      "distance" : "200-250",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "561",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : true,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : true,
+         "isMonthParkAndRide" : true,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffDiscount" : "Rabattierung mit BahnCard direkt am Kassenautomaten. Bonierung an der DB Information. Bitte beachten Sie die Öffnungszeiten der DB Information.",
+         "tariffFreeParkingTime" : "nein",
+         "tariffSpecialEn" : "2nd and further hours will be calculated per hour. 2nd and additional weeks: max. 30.00. Event tariff (available 4pm till 9pm, valid 4pm till 3am): 6.00. Park+Ride-Tickets at the DB Reisezentrum (limited availability): Month: 30.00",
+         "tariffSpecial" : "Stundentakt ab der 2. Parkstunde. 2. u. weitere Wochen: max. 30,00. Veranstaltungstarif, erhältlich 16:00 bis 21:00 Uhr (gültig 16:00 bis 03:00 Uhr): 6,00. Park+Ride-Karten im Reisezentrum für Kunden mit Zeitfahrkarte (begrenztes Kontingent): Monat: 30,00",
+         "tariffDiscountEn" : "BahnCard discount available directly at the pay station. Reduction from the DB Information. Please note the DB Information's opening hours. ",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA), EC-Karte",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA), EC-Card"
+      },
+      "tariffPrices" : [ {
+         "id" : 293527,
+         "duration" : "20min"
+      }, {
+         "id" : 293528,
+         "duration" : "30min",
+         "price" : 0.7
+      }, {
+         "id" : 293529,
+         "duration" : "1hour",
+         "price" : 1.7
+      }, {
+         "id" : 293530,
+         "duration" : "1day",
+         "price" : 11.0
+      }, {
+         "id" : 293531,
+         "duration" : "1dayDiscount",
+         "price" : 9.0
+      }, {
+         "id" : 293532,
+         "duration" : "1week",
+         "price" : 40.0
+      }, {
+         "id" : 293533,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 293534,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 293535,
+         "duration" : "1monthLongTerm",
+         "price" : 80.0
+      }, {
+         "id" : 293536,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100113,
+      "title" : "Halle (Saale) Hbf P1 Parkplatz Halle Hbf Ernst-Kamieth-Straße",
+      "station" : {
+         "id" : 2498,
+         "name" : "Halle (Saale) Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "79",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Ernst-Kamieth-Straße",
+      "nameDisplay" : "Parkplatz Halle Hbf Ernst-Kamieth-Straße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 11.985823,
+         "latitude" : 51.47668
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8010159.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Halle an der Saale",
+         "postalCode" : "06112",
+         "street" : "Ernst-Kamieth-Straße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "75",
+      "numberHandicapedPlaces" : "2",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks from the parking ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 219482,
+         "duration" : "20min"
+      }, {
+         "id" : 219483,
+         "duration" : "30min"
+      }, {
+         "id" : 219484,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 219485,
+         "duration" : "1day",
+         "price" : 5.0
+      }, {
+         "id" : 219486,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219487,
+         "duration" : "1week",
+         "price" : 25.0
+      }, {
+         "id" : 219488,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219489,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219490,
+         "duration" : "1monthLongTerm",
+         "price" : 60.0
+      }, {
+         "id" : 219491,
+         "duration" : "1monthReservation",
+         "price" : 90.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100114,
+      "title" : "Halle (Saale) Hbf P3 Halle Hbf P3 Tiefgarage Charlottencenter",
+      "station" : {
+         "id" : 2498,
+         "name" : "Halle (Saale) Hbf"
+      },
+      "label" : "P3",
+      "spaceNumber" : "366",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Tiefgarage Charlottencenter",
+      "nameDisplay" : "Halle Hbf P3 Tiefgarage Charlottencenter",
+      "spaceType" : "Tiefgarage",
+      "spaceTypeEn" : "Underground car park",
+      "spaceTypeName" : "Tiefgarage",
+      "geoLocation" : {
+         "longitude" : 11.980912,
+         "latitude" : 51.480373
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8010159.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Halle an der Saale",
+         "postalCode" : "06108",
+         "street" : "Dorotheenstraße"
+      },
+      "distance" : ">250",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "472",
+      "numberHandicapedPlaces" : "11",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "275",
+         "clearanceHeight" : "200",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffSpecialEn" : "2nd and additional days: 10.00 flat. The daily tariff applies per parking session per calendar day (first day till 3.00am). First day with P Card: 3.00 max. Movie theatre tariff: Up to 4 hours 1.50.",
+         "tariffSpecial" : "2. und weiterer Tag: 10,00 pauschal. Die Berechnung erfolgt je Parkvorgang pro Kalendertag (am ersten Tag bis 03:00 Uhr früh). 1. Tag mit P Card max. 3,00. Kinotarif: Bis 4 Stunden 1,50.",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA), EC-Karte, P Card",
+         "tariffPaymentCustomerCards" : "P Card",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA), EC-Card, P Card"
+      },
+      "tariffPrices" : [ {
+         "id" : 219492,
+         "duration" : "20min"
+      }, {
+         "id" : 219493,
+         "duration" : "30min"
+      }, {
+         "id" : 219494,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 219495,
+         "duration" : "1day",
+         "price" : 3.5
+      }, {
+         "id" : 219496,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219497,
+         "duration" : "1week"
+      }, {
+         "id" : 219498,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219499,
+         "duration" : "1monthVendingMachine",
+         "price" : 95.0
+      }, {
+         "id" : 219500,
+         "duration" : "1monthLongTerm",
+         "price" : 80.0
+      }, {
+         "id" : 219501,
+         "duration" : "1monthReservation",
+         "price" : 120.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100115,
+      "title" : "Hamburg Hbf P1 Hamburg Hbf P1 Parkhaus Hbf Centrum Hühnerposten",
+      "station" : {
+         "id" : 2514,
+         "name" : "Hamburg Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "277",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkhaus Hauptbahnhof Centrum Hühnerposten",
+      "nameDisplay" : "Hamburg Hbf P1 Parkhaus Hbf Centrum Hühnerposten",
+      "spaceType" : "Parkhaus",
+      "spaceTypeEn" : "Multi storey car park",
+      "spaceTypeName" : "Parkhaus",
+      "geoLocation" : {
+         "longitude" : 10.00777,
+         "latitude" : 53.549201
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8002549.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Hamburg",
+         "postalCode" : "20097",
+         "street" : "Hühnerposten"
+      },
+      "distance" : "300",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "04:00 - 22:00 Uhr. Ausfahrt jederzeit möglich.",
+      "openingHoursEn" : "4:00am - 10:00pm, exit possible at any time.  ",
+      "numberParkingPlaces" : "427",
+      "numberHandicapedPlaces" : "7",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "260",
+         "clearanceHeight" : "200",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffSpecialEn" : "Up to 4 hours: 4.00; each additional hour: 2.00",
+         "tariffSpecial" : "Bis 4 Stunden: 4,00; je weitere Stunde 2,00",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA), EC-Karte",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA), EC-Card"
+      },
+      "tariffPrices" : [ {
+         "id" : 219512,
+         "duration" : "20min"
+      }, {
+         "id" : 219513,
+         "duration" : "30min"
+      }, {
+         "id" : 219514,
+         "duration" : "1hour"
+      }, {
+         "id" : 219515,
+         "duration" : "1day",
+         "price" : 10.0
+      }, {
+         "id" : 219516,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219517,
+         "duration" : "1week"
+      }, {
+         "id" : 219518,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219519,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219520,
+         "duration" : "1monthLongTerm",
+         "price" : 180.0
+      }, {
+         "id" : 219521,
+         "duration" : "1monthReservation",
+         "price" : 250.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100116,
+      "title" : "Hamburg Hbf P2 Parkplatz Hühnerposten",
+      "station" : {
+         "id" : 2514,
+         "name" : "Hamburg Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "376",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Hühnerposten",
+      "nameDisplay" : "Parkplatz Hühnerposten",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 10.008548,
+         "latitude" : 53.549487
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8002549.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Hamburg",
+         "postalCode" : "20097",
+         "street" : "Hühnerposten 1-2"
+      },
+      "distance" : "350",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "16",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "328",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 3 days",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 3 Tage",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219522,
+         "duration" : "20min"
+      }, {
+         "id" : 219523,
+         "duration" : "30min"
+      }, {
+         "id" : 219524,
+         "duration" : "1hour",
+         "price" : 2.5
+      }, {
+         "id" : 219525,
+         "duration" : "1day",
+         "price" : 15.0
+      }, {
+         "id" : 219526,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219527,
+         "duration" : "1week"
+      }, {
+         "id" : 219528,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219529,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219530,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219531,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100118,
+      "title" : "Hamburg-Harburg P1 Parkplatz Bahnhof Hamburg-Harburg",
+      "station" : {
+         "id" : 2519,
+         "name" : "Hamburg-Harburg"
+      },
+      "label" : "P1",
+      "spaceNumber" : "80",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Hamburg-Harburg",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.99055,
+         "latitude" : 53.455673
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000147.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Hamburg",
+         "postalCode" : "21079",
+         "street" : "Hannoversche Straße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "54",
+      "numberHandicapedPlaces" : "2",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "470",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : true,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks from the parking ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffPointOfSale" : "Park&Rail-Karten erhältlich an allen Verkaufsstellen der Deutschen Bahn (außer Internet).",
+         "tariffPointOfSaleEn" : "Park&Rail cards available from all Deutsche Bahn points of sale (except online).  ",
+         "tariffMaxParkingTime" : "Max. 2 Wochen am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219502,
+         "duration" : "20min"
+      }, {
+         "id" : 219503,
+         "duration" : "30min",
+         "price" : 1.0
+      }, {
+         "id" : 219504,
+         "duration" : "1hour",
+         "price" : 2.0
+      }, {
+         "id" : 219505,
+         "duration" : "1day",
+         "price" : 7.0
+      }, {
+         "id" : 219506,
+         "duration" : "1dayDiscount",
+         "price" : 6.0
+      }, {
+         "id" : 219507,
+         "duration" : "1week",
+         "price" : 35.0
+      }, {
+         "id" : 219508,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219509,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219510,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219511,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100119,
+      "title" : "Hamm (Westf) P3 Parkplatz Bahnhof Hamm",
+      "station" : {
+         "id" : 2528,
+         "name" : "Hamm (Westf)"
+      },
+      "label" : "P3",
+      "spaceNumber" : "82",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Hamm",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 7.806336,
+         "latitude" : 51.677051
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000149.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Hamm in Westfalen",
+         "postalCode" : "59067",
+         "street" : "Unionstraße"
+      },
+      "distance" : "100-149",
+      "facilityType" : "keine",
+      "facilityTypeEn" : "none",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "19",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : true,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffPointOfSale" : "Park&Rail-Karten erhältlich an allen Verkaufsstellen der Deutschen Bahn (außer Internet).",
+         "tariffPointOfSaleEn" : "Park&Rail cards available from all Deutsche Bahn points of sale (except online).  ",
+         "tarifNotesEn" : "Please note the opening times of the local DB points of sale. ",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffNotes" : "Bitte beachten Sie die Öffnungszeiten der örtlichen DB Verkaufsstellen."
+      },
+      "tariffPrices" : [ {
+         "id" : 219532,
+         "duration" : "20min"
+      }, {
+         "id" : 219533,
+         "duration" : "30min"
+      }, {
+         "id" : 219534,
+         "duration" : "1hour"
+      }, {
+         "id" : 219535,
+         "duration" : "1day",
+         "price" : 5.0
+      }, {
+         "id" : 219536,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219537,
+         "duration" : "1week"
+      }, {
+         "id" : 219538,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219539,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219540,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219541,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100120,
+      "title" : "Hanau Hbf P1 Vorplatz Hanau Hbf",
+      "station" : {
+         "id" : 2537,
+         "name" : "Hanau Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "84",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Vorplatz Hanau Hbf",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.929814,
+         "latitude" : 50.121738
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000150.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Hanau",
+         "postalCode" : "63451",
+         "street" : "Am Hauptbahnhof"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "20",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "clearanceHeight" : "300",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Woche",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219542,
+         "duration" : "20min"
+      }, {
+         "id" : 219543,
+         "duration" : "30min",
+         "price" : 1.0
+      }, {
+         "id" : 219544,
+         "duration" : "1hour",
+         "price" : 2.0
+      }, {
+         "id" : 219545,
+         "duration" : "1day",
+         "price" : 5.0
+      }, {
+         "id" : 219546,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219547,
+         "duration" : "1week",
+         "price" : 25.0
+      }, {
+         "id" : 219548,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219549,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219550,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219551,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100121,
+      "title" : "Hanau Hbf P2 Parkplatz Hanau Hbf zwischen den Gleisen",
+      "station" : {
+         "id" : 2537,
+         "name" : "Hanau Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "85",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Hanau Hbf zwischen den Gleisen",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.927262,
+         "latitude" : 50.121857
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000150.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Hanau",
+         "postalCode" : "63452",
+         "street" : "Alter Hauptbahnhof"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "270",
+      "numberHandicapedPlaces" : "3",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "clearanceHeight" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219552,
+         "duration" : "20min"
+      }, {
+         "id" : 219553,
+         "duration" : "30min",
+         "price" : 0.55
+      }, {
+         "id" : 219554,
+         "duration" : "1hour",
+         "price" : 1.1
+      }, {
+         "id" : 219555,
+         "duration" : "1day",
+         "price" : 3.5
+      }, {
+         "id" : 219556,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219557,
+         "duration" : "1week",
+         "price" : 17.5
+      }, {
+         "id" : 219558,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219559,
+         "duration" : "1monthVendingMachine",
+         "price" : 43.0
+      }, {
+         "id" : 219560,
+         "duration" : "1monthLongTerm",
+         "price" : 43.0
+      }, {
+         "id" : 219561,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100122,
+      "title" : "Hanau Hbf P3 Parkplatz Hanau Hbf Güterbahnhofstraße",
+      "station" : {
+         "id" : 2537,
+         "name" : "Hanau Hbf"
+      },
+      "label" : "P3",
+      "spaceNumber" : "86",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Hanau Hbf Güterbahnhofstraße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.928447,
+         "latitude" : 50.122254
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000150.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Hanau",
+         "postalCode" : "63450",
+         "street" : "Güterbahnhofstraße"
+      },
+      "distance" : "100-149",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "60",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "clearanceHeight" : "300",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219562,
+         "duration" : "20min"
+      }, {
+         "id" : 219563,
+         "duration" : "30min",
+         "price" : 0.55
+      }, {
+         "id" : 219564,
+         "duration" : "1hour",
+         "price" : 1.1
+      }, {
+         "id" : 219565,
+         "duration" : "1day",
+         "price" : 3.5
+      }, {
+         "id" : 219566,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219567,
+         "duration" : "1week",
+         "price" : 17.5
+      }, {
+         "id" : 219568,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219569,
+         "duration" : "1monthVendingMachine",
+         "price" : 43.0
+      }, {
+         "id" : 219570,
+         "duration" : "1monthLongTerm",
+         "price" : 43.0
+      }, {
+         "id" : 219571,
+         "duration" : "1monthReservation",
+         "price" : 70.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100123,
+      "title" : "Hanau Hbf P4 Parkplatz Hanau Hbf Vorderseite rechts",
+      "station" : {
+         "id" : 2537,
+         "name" : "Hanau Hbf"
+      },
+      "label" : "P4",
+      "spaceNumber" : "229",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Hanau Hbf Vorderseite rechts",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.92967,
+         "latitude" : 50.122427
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000150.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Hanau",
+         "postalCode" : "63450",
+         "street" : "Am Hauptbahnhof"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "180",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "clearanceHeight" : "300",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219572,
+         "duration" : "20min"
+      }, {
+         "id" : 219573,
+         "duration" : "30min",
+         "price" : 0.55
+      }, {
+         "id" : 219574,
+         "duration" : "1hour",
+         "price" : 1.1
+      }, {
+         "id" : 219575,
+         "duration" : "1day",
+         "price" : 3.5
+      }, {
+         "id" : 219576,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219577,
+         "duration" : "1week",
+         "price" : 17.5
+      }, {
+         "id" : 219578,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219579,
+         "duration" : "1monthVendingMachine",
+         "price" : 43.0
+      }, {
+         "id" : 219580,
+         "duration" : "1monthLongTerm",
+         "price" : 43.0
+      }, {
+         "id" : 219581,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100124,
+      "title" : "Hanau Hbf P5 Parkplatz Hanau Hbf Vorderseite links",
+      "station" : {
+         "id" : 2537,
+         "name" : "Hanau Hbf"
+      },
+      "label" : "P5",
+      "spaceNumber" : "83",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Hanau Hbf Vorderseite links",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.932183,
+         "latitude" : 50.121033
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000150.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Hanau",
+         "postalCode" : "63450",
+         "street" : "Boschstraße"
+      },
+      "distance" : "100-149",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "156",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "340",
+         "clearanceHeight" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219582,
+         "duration" : "20min"
+      }, {
+         "id" : 219583,
+         "duration" : "30min",
+         "price" : 0.55
+      }, {
+         "id" : 219584,
+         "duration" : "1hour",
+         "price" : 1.1
+      }, {
+         "id" : 219585,
+         "duration" : "1day",
+         "price" : 3.5
+      }, {
+         "id" : 219586,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219587,
+         "duration" : "1week",
+         "price" : 17.5
+      }, {
+         "id" : 219588,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219589,
+         "duration" : "1monthVendingMachine",
+         "price" : 43.0
+      }, {
+         "id" : 219590,
+         "duration" : "1monthLongTerm",
+         "price" : 43.0
+      }, {
+         "id" : 219591,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100125,
+      "title" : "Hannover Hbf P1 Hannover Hbf Ernst-August-Platz rechts",
+      "station" : {
+         "id" : 2545,
+         "name" : "Hannover Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "87",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Ernst-August-Platz",
+      "nameDisplay" : "Hannover Hbf Ernst-August-Platz rechts",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.741477,
+         "latitude" : 52.375911
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000152.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Hannover",
+         "postalCode" : "30159",
+         "street" : "Fernroderstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "13",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "250",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 day",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Tag",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 227264,
+         "duration" : "20min"
+      }, {
+         "id" : 227265,
+         "duration" : "30min",
+         "price" : 2.0
+      }, {
+         "id" : 227266,
+         "duration" : "1hour",
+         "price" : 4.0
+      }, {
+         "id" : 227267,
+         "duration" : "1day",
+         "price" : 20.0
+      }, {
+         "id" : 227268,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 227269,
+         "duration" : "1week"
+      }, {
+         "id" : 227270,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 227271,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 227272,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 227273,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100126,
+      "title" : "Hannover Hbf P2 Hannover Hbf Ernst-August-Platz links",
+      "station" : {
+         "id" : 2545,
+         "name" : "Hannover Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "88",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Ernst-August-Platz",
+      "nameDisplay" : "Hannover Hbf Ernst-August-Platz links",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.739688,
+         "latitude" : 52.376689
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000152.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Hannover",
+         "postalCode" : "30159",
+         "street" : "Kurt-Schumacher-Straße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "14",
+      "numberHandicapedPlaces" : "3",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "250",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 day",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Tag",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219602,
+         "duration" : "20min"
+      }, {
+         "id" : 219603,
+         "duration" : "30min",
+         "price" : 2.0
+      }, {
+         "id" : 219604,
+         "duration" : "1hour",
+         "price" : 4.0
+      }, {
+         "id" : 219605,
+         "duration" : "1day",
+         "price" : 20.0
+      }, {
+         "id" : 219606,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219607,
+         "duration" : "1week"
+      }, {
+         "id" : 219608,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219609,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219610,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219611,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100127,
+      "title" : "Hannover Hbf P3 Parkplatz Hannover Hbf Fernroder Straße",
+      "station" : {
+         "id" : 2545,
+         "name" : "Hannover Hbf"
+      },
+      "label" : "P3",
+      "spaceNumber" : "90",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Hannover Hbf Fernroder Straße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.743777,
+         "latitude" : 52.377008
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000152.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Hannover",
+         "postalCode" : "30159",
+         "street" : "Fernroder Straße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "7",
+      "numberHandicapedPlaces" : "1",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 day",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Tag",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219612,
+         "duration" : "20min"
+      }, {
+         "id" : 219613,
+         "duration" : "30min",
+         "price" : 1.5
+      }, {
+         "id" : 219614,
+         "duration" : "1hour",
+         "price" : 3.0
+      }, {
+         "id" : 219615,
+         "duration" : "1day",
+         "price" : 15.0
+      }, {
+         "id" : 219616,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219617,
+         "duration" : "1week"
+      }, {
+         "id" : 219618,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219619,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219620,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219621,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100128,
+      "title" : "Hannover Hbf P4 Parkplatz Hannover Hbf ZOB, Lister Meile",
+      "station" : {
+         "id" : 2545,
+         "name" : "Hannover Hbf"
+      },
+      "label" : "P4",
+      "spaceNumber" : "89",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz am ZOB, Lister Meile",
+      "nameDisplay" : "Parkplatz Hannover Hbf ZOB, Lister Meile",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.741103,
+         "latitude" : 52.378293
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000152.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Hannover",
+         "postalCode" : "30159",
+         "street" : "Lister Meile"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "29",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks from the parking ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219622,
+         "duration" : "20min"
+      }, {
+         "id" : 219623,
+         "duration" : "30min",
+         "price" : 1.5
+      }, {
+         "id" : 219624,
+         "duration" : "1hour",
+         "price" : 3.0
+      }, {
+         "id" : 219625,
+         "duration" : "1day",
+         "price" : 5.0
+      }, {
+         "id" : 219626,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219627,
+         "duration" : "1week",
+         "price" : 35.0
+      }, {
+         "id" : 219628,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219629,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219630,
+         "duration" : "1monthLongTerm",
+         "price" : 150.0
+      }, {
+         "id" : 219631,
+         "duration" : "1monthReservation",
+         "price" : 200.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100129,
+      "title" : "Hannover Hbf P6 Parkplatz Hannover Hbf Augustenstraße",
+      "station" : {
+         "id" : 2545,
+         "name" : "Hannover Hbf"
+      },
+      "label" : "P6",
+      "spaceNumber" : "316",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Hauptbahnhof Augustenstraße",
+      "nameDisplay" : "Parkplatz Hannover Hbf Augustenstraße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.745623,
+         "latitude" : 52.375787
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000152.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Hannover",
+         "postalCode" : "30161",
+         "street" : "Augustenstraße"
+      },
+      "distance" : "200-250",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "140",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 749346,
+         "duration" : "20min"
+      }, {
+         "id" : 749347,
+         "duration" : "30min"
+      }, {
+         "id" : 749348,
+         "duration" : "1hour",
+         "price" : 2.0
+      }, {
+         "id" : 749349,
+         "duration" : "1day",
+         "price" : 12.0
+      }, {
+         "id" : 749350,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 749351,
+         "duration" : "1week",
+         "price" : 25.0
+      }, {
+         "id" : 749352,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 749353,
+         "duration" : "1monthVendingMachine",
+         "price" : 70.0
+      }, {
+         "id" : 749354,
+         "duration" : "1monthLongTerm",
+         "price" : 70.0
+      }, {
+         "id" : 749355,
+         "duration" : "1monthReservation",
+         "price" : 110.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100130,
+      "title" : "Hannover Hbf P7 Hannover Hbf P7 Tiefgarage Augustenstraße",
+      "station" : {
+         "id" : 2545,
+         "name" : "Hannover Hbf"
+      },
+      "label" : "P7",
+      "spaceNumber" : "418",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Tiefgarage Hauptbahnhof Augustenstraße",
+      "nameDisplay" : "Hannover Hbf P7 Tiefgarage Augustenstraße",
+      "spaceType" : "Tiefgarage",
+      "spaceTypeEn" : "Underground car park",
+      "spaceTypeName" : "Tiefgarage",
+      "geoLocation" : {
+         "longitude" : 9.745419,
+         "latitude" : 52.376227
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000152.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Hannover",
+         "postalCode" : "30161",
+         "street" : "Augustenstraße"
+      },
+      "distance" : "200-250",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "06:00 - 22:00 Uhr",
+      "openingHoursEn" : "6:00am - 10:00pm",
+      "numberParkingPlaces" : "145",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA), EC-Karte, P Card",
+         "tariffPaymentCustomerCards" : "P Card",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA), EC-Card, P Card"
+      },
+      "tariffPrices" : [ {
+         "id" : 219642,
+         "duration" : "20min"
+      }, {
+         "id" : 219643,
+         "duration" : "30min"
+      }, {
+         "id" : 219644,
+         "duration" : "1hour",
+         "price" : 2.0
+      }, {
+         "id" : 219645,
+         "duration" : "1day",
+         "price" : 6.0
+      }, {
+         "id" : 219646,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219647,
+         "duration" : "1week"
+      }, {
+         "id" : 219648,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219649,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219650,
+         "duration" : "1monthLongTerm",
+         "price" : 125.0
+      }, {
+         "id" : 219651,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100131,
+      "title" : "Heidelberg Hbf P1 Parkplatz Heidelberg Hbf Kurfürstenanl.",
+      "station" : {
+         "id" : 2628,
+         "name" : "Heidelberg Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "91",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Heidelberg Hbf Kurfürstenanl.",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.674536,
+         "latitude" : 49.404976
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000156.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Heidelberg",
+         "postalCode" : "69115",
+         "street" : "Willy-Brandt-Platz / Kurfürstenanlage"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "56",
+      "numberHandicapedPlaces" : "1",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : true,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week from the parking ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffPointOfSale" : "Park&Rail-Karten erhältlich an allen Verkaufsstellen der Deutschen Bahn (außer Internet).",
+         "tariffPointOfSaleEn" : "Park&Rail cards available from all Deutsche Bahn points of sale (except online).  ",
+         "tariffMaxParkingTime" : "Max. 1 Woche am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219652,
+         "duration" : "20min"
+      }, {
+         "id" : 219653,
+         "duration" : "30min",
+         "price" : 0.7
+      }, {
+         "id" : 219654,
+         "duration" : "1hour",
+         "price" : 1.4
+      }, {
+         "id" : 219655,
+         "duration" : "1day",
+         "price" : 10.0
+      }, {
+         "id" : 219656,
+         "duration" : "1dayDiscount",
+         "price" : 8.5
+      }, {
+         "id" : 219657,
+         "duration" : "1week",
+         "price" : 40.0
+      }, {
+         "id" : 219658,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219659,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219660,
+         "duration" : "1monthLongTerm",
+         "price" : 75.0
+      }, {
+         "id" : 219661,
+         "duration" : "1monthReservation",
+         "price" : 100.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100132,
+      "title" : "Heidelberg Hbf P2 Parkplatz Heidelberg Hbf Lessingstraße",
+      "station" : {
+         "id" : 2628,
+         "name" : "Heidelberg Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "92",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Heidelberg Hbf Lessingstraße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.677944,
+         "latitude" : 49.402839
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000156.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Heidelberg",
+         "postalCode" : "69115",
+         "street" : "Lessingstraße",
+         "supplement" : "unterhalb Montpellierbrücke",
+         "supplementEn" : "below Montpellierbrücke"
+      },
+      "distance" : "200-250",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "90",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 10 days or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 10 Tage oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219662,
+         "duration" : "20min"
+      }, {
+         "id" : 219663,
+         "duration" : "30min",
+         "price" : 0.7
+      }, {
+         "id" : 219664,
+         "duration" : "1hour",
+         "price" : 1.4
+      }, {
+         "id" : 219665,
+         "duration" : "1day",
+         "price" : 10.0
+      }, {
+         "id" : 219666,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219667,
+         "duration" : "1week",
+         "price" : 40.0
+      }, {
+         "id" : 219668,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219669,
+         "duration" : "1monthVendingMachine",
+         "price" : 75.0
+      }, {
+         "id" : 219670,
+         "duration" : "1monthLongTerm",
+         "price" : 75.0
+      }, {
+         "id" : 219671,
+         "duration" : "1monthReservation",
+         "price" : 100.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100133,
+      "title" : "Heidelberg Hbf P3 Parkplatz Heidelberg Hbf Czernyring",
+      "station" : {
+         "id" : 2628,
+         "name" : "Heidelberg Hbf"
+      },
+      "label" : "P3",
+      "spaceNumber" : "364",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Heidelberg Hbf Czernyring",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.675318,
+         "latitude" : 49.402826
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000156.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Heidelberg",
+         "postalCode" : "69115",
+         "street" : "Czernyring"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "48",
+      "numberHandicapedPlaces" : "2",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "600",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219672,
+         "duration" : "20min"
+      }, {
+         "id" : 219673,
+         "duration" : "30min",
+         "price" : 0.8
+      }, {
+         "id" : 219674,
+         "duration" : "1hour",
+         "price" : 1.6
+      }, {
+         "id" : 219675,
+         "duration" : "1day",
+         "price" : 10.0
+      }, {
+         "id" : 219676,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219677,
+         "duration" : "1week",
+         "price" : 40.0
+      }, {
+         "id" : 219678,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219679,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219680,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219681,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100134,
+      "title" : "Heilbronn Hbf P1 Heilbronn Hbf P1 Parkplatz",
+      "station" : {
+         "id" : 2648,
+         "name" : "Heilbronn Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "95",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Heilbronn Hauptbahnhof",
+      "nameDisplay" : "Heilbronn Hbf P1 Parkplatz",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.212226,
+         "latitude" : 49.143582
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000157.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Heilbronn",
+         "postalCode" : "74072",
+         "street" : "Bahnhofstraße 11"
+      },
+      "distance" : "100-149",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "511",
+      "numberHandicapedPlaces" : "3",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "240",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : true,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : true,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffDiscount" : "Rabattierung mit BahnCard direkt am Kassenautomaten. Bonierung an der DB Information.",
+         "tariffFreeParkingTime" : "nein",
+         "tariffDiscountEn" : "BahnCard discount available directly at the pay station. Reduction from the DB Information.",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA), P Card",
+         "tariffPaymentCustomerCards" : "P Card",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA), P Card"
+      },
+      "tariffPrices" : [ {
+         "id" : 219682,
+         "duration" : "20min"
+      }, {
+         "id" : 219683,
+         "duration" : "30min"
+      }, {
+         "id" : 219684,
+         "duration" : "1hour",
+         "price" : 1.5
+      }, {
+         "id" : 219685,
+         "duration" : "1day",
+         "price" : 8.0
+      }, {
+         "id" : 219686,
+         "duration" : "1dayDiscount",
+         "price" : 6.5
+      }, {
+         "id" : 219687,
+         "duration" : "1week",
+         "price" : 35.0
+      }, {
+         "id" : 219688,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219689,
+         "duration" : "1monthVendingMachine",
+         "price" : 80.0
+      }, {
+         "id" : 219690,
+         "duration" : "1monthLongTerm",
+         "price" : 80.0
+      }, {
+         "id" : 219691,
+         "duration" : "1monthReservation",
+         "price" : 110.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100136,
+      "title" : "Herrenberg P1 Parkplatz Bahnhof Herrenberg",
+      "station" : {
+         "id" : 2726,
+         "name" : "Herrenberg"
+      },
+      "label" : "P1",
+      "spaceNumber" : "452",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Bahnhof Herrenberg",
+      "nameDisplay" : "Parkplatz Bahnhof Herrenberg",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.861743,
+         "latitude" : 48.593261
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8002785.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Herrenberg",
+         "postalCode" : "71083",
+         "street" : "Bahnhofstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "122",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week from the parking ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 1 Woche am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 219692,
+         "duration" : "20min"
+      }, {
+         "id" : 219693,
+         "duration" : "30min"
+      }, {
+         "id" : 219694,
+         "duration" : "1hour",
+         "price" : 0.6
+      }, {
+         "id" : 219695,
+         "duration" : "1day",
+         "price" : 2.2
+      }, {
+         "id" : 219696,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219697,
+         "duration" : "1week",
+         "price" : 11.0
+      }, {
+         "id" : 219698,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219699,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219700,
+         "duration" : "1monthLongTerm",
+         "price" : 20.0
+      }, {
+         "id" : 219701,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100137,
+      "title" : "Hersbruck (rechts Pegnitz) P1 Bahnhof Hersbruck Kurzzeitparkplatz",
+      "station" : {
+         "id" : 2734,
+         "name" : "Hersbruck (rechts Pegnitz)"
+      },
+      "label" : "P1",
+      "spaceNumber" : "428",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Kurzzeitparkplatz",
+      "nameDisplay" : "Bahnhof Hersbruck Kurzzeitparkplatz",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 11.425012,
+         "latitude" : 49.509909
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8002794.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Hersbruck",
+         "postalCode" : "91217",
+         "street" : "Bahngelände"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "14",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 hours",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Stunden",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 219702,
+         "duration" : "20min"
+      }, {
+         "id" : 219703,
+         "duration" : "30min",
+         "price" : 0.5
+      }, {
+         "id" : 219704,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 219705,
+         "duration" : "1day"
+      }, {
+         "id" : 219706,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219707,
+         "duration" : "1week"
+      }, {
+         "id" : 219708,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219709,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219710,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219711,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100138,
+      "title" : "Hersbruck (rechts Pegnitz) P2 Bahnhof Hersbruck Vorderseite",
+      "station" : {
+         "id" : 2734,
+         "name" : "Hersbruck (rechts Pegnitz)"
+      },
+      "label" : "P2",
+      "spaceNumber" : "429",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Bahnhof Hersbruck Vorderseite",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 11.423041,
+         "latitude" : 49.509658
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8002794.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Hersbruck",
+         "postalCode" : "91217",
+         "street" : "Bahngelände"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "125",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 219712,
+         "duration" : "20min"
+      }, {
+         "id" : 219713,
+         "duration" : "30min"
+      }, {
+         "id" : 219714,
+         "duration" : "1hour"
+      }, {
+         "id" : 219715,
+         "duration" : "1day",
+         "price" : 1.2
+      }, {
+         "id" : 219716,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219717,
+         "duration" : "1week",
+         "price" : 5.0
+      }, {
+         "id" : 219718,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219719,
+         "duration" : "1monthVendingMachine",
+         "price" : 15.0
+      }, {
+         "id" : 219720,
+         "duration" : "1monthLongTerm",
+         "price" : 15.0
+      }, {
+         "id" : 219721,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100139,
+      "title" : "Hersbruck (rechts Pegnitz) P3 Bahnhof Hersbruck Vorderseite links",
+      "station" : {
+         "id" : 2734,
+         "name" : "Hersbruck (rechts Pegnitz)"
+      },
+      "label" : "P3",
+      "spaceNumber" : "430",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Bahnhof Hersbruck Vorderseite links",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 11.420634,
+         "latitude" : 49.509274
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8002794.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Hersbruck",
+         "postalCode" : "91217",
+         "street" : "Bahngelände"
+      },
+      "distance" : "100-149",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "60",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 219722,
+         "duration" : "20min"
+      }, {
+         "id" : 219723,
+         "duration" : "30min"
+      }, {
+         "id" : 219724,
+         "duration" : "1hour"
+      }, {
+         "id" : 219725,
+         "duration" : "1day",
+         "price" : 1.2
+      }, {
+         "id" : 219726,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219727,
+         "duration" : "1week",
+         "price" : 5.0
+      }, {
+         "id" : 219728,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219729,
+         "duration" : "1monthVendingMachine",
+         "price" : 15.0
+      }, {
+         "id" : 219730,
+         "duration" : "1monthLongTerm",
+         "price" : 15.0
+      }, {
+         "id" : 219731,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100140,
+      "title" : "Hildesheim Hbf P2 Parkplatz Hildesheim Hbf Rückseite",
+      "station" : {
+         "id" : 2765,
+         "name" : "Hildesheim Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "216",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Hauptbahnhof Nord",
+      "nameDisplay" : "Parkplatz Hildesheim Hbf Rückseite",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.952323,
+         "latitude" : 52.160717
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000169.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Hildesheim",
+         "postalCode" : "31134",
+         "street" : "Altes Dorf"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "24",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "229.99999999999997",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 10 days or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 10 Tage oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219732,
+         "duration" : "20min"
+      }, {
+         "id" : 219733,
+         "duration" : "30min",
+         "price" : 0.7
+      }, {
+         "id" : 219734,
+         "duration" : "1hour",
+         "price" : 1.4
+      }, {
+         "id" : 219735,
+         "duration" : "1day",
+         "price" : 5.2
+      }, {
+         "id" : 219736,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219737,
+         "duration" : "1week",
+         "price" : 20.8
+      }, {
+         "id" : 219738,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219739,
+         "duration" : "1monthVendingMachine",
+         "price" : 40.0
+      }, {
+         "id" : 219740,
+         "duration" : "1monthLongTerm",
+         "price" : 40.0
+      }, {
+         "id" : 219741,
+         "duration" : "1monthReservation",
+         "price" : 60.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100141,
+      "title" : "Hildesheim Hbf P3 Hildesheim Hbf Bischof-Janssen-Str.",
+      "station" : {
+         "id" : 2765,
+         "name" : "Hildesheim Hbf"
+      },
+      "label" : "P3",
+      "spaceNumber" : "427",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Hauptbahnhof West",
+      "nameDisplay" : "Hildesheim Hbf Bischof-Janssen-Str.",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.949124,
+         "latitude" : 52.15819
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000169.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Hildesheim",
+         "postalCode" : "31134",
+         "street" : "Bischof-Janssen-Straße"
+      },
+      "distance" : "200-250",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "90",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 743498,
+         "duration" : "20min"
+      }, {
+         "id" : 743499,
+         "duration" : "30min"
+      }, {
+         "id" : 743500,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 743501,
+         "duration" : "1day",
+         "price" : 3.0
+      }, {
+         "id" : 743502,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 743503,
+         "duration" : "1week",
+         "price" : 15.0
+      }, {
+         "id" : 743504,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 743505,
+         "duration" : "1monthVendingMachine",
+         "price" : 40.0
+      }, {
+         "id" : 743506,
+         "duration" : "1monthLongTerm",
+         "price" : 40.0
+      }, {
+         "id" : 743507,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100143,
+      "title" : "Hof Hbf P1 Vorfahrt Hof Hbf",
+      "station" : {
+         "id" : 2818,
+         "name" : "Hof Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "98",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Vorfahrt Hof Hbf",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 11.923359,
+         "latitude" : 50.308478
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8002924.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Hof",
+         "postalCode" : "95028",
+         "street" : "Bahnhofsplatz"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "23",
+      "numberHandicapedPlaces" : "2",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 219752,
+         "duration" : "20min"
+      }, {
+         "id" : 219753,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 219754,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 219755,
+         "duration" : "1day",
+         "price" : 3.0
+      }, {
+         "id" : 219756,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219757,
+         "duration" : "1week",
+         "price" : 12.0
+      }, {
+         "id" : 219758,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219759,
+         "duration" : "1monthVendingMachine",
+         "price" : 35.0
+      }, {
+         "id" : 219760,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219761,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100144,
+      "title" : "Hof Hbf P2 Parkplatz Hof Hbf Rondell links",
+      "station" : {
+         "id" : 2818,
+         "name" : "Hof Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "97",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Hof Hbf Rondell links",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 11.92425,
+         "latitude" : 50.30801
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8002924.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Hof",
+         "postalCode" : "95028",
+         "street" : "Bahnhofsplatz 14",
+         "supplement" : "östliches Rondell",
+         "supplementEn" : "eastern roundabout"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "30",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 219762,
+         "duration" : "20min"
+      }, {
+         "id" : 219763,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 219764,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 219765,
+         "duration" : "1day",
+         "price" : 3.0
+      }, {
+         "id" : 219766,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219767,
+         "duration" : "1week",
+         "price" : 12.0
+      }, {
+         "id" : 219768,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219769,
+         "duration" : "1monthVendingMachine",
+         "price" : 35.0
+      }, {
+         "id" : 219770,
+         "duration" : "1monthLongTerm",
+         "price" : 35.0
+      }, {
+         "id" : 219771,
+         "duration" : "1monthReservation",
+         "price" : 45.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100145,
+      "title" : "Hof Hbf P3 Parkplatz Hof Hbf Rondell rechts",
+      "station" : {
+         "id" : 2818,
+         "name" : "Hof Hbf"
+      },
+      "label" : "P3",
+      "spaceNumber" : "96",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Hof Hbf Rondell rechts",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 11.922821,
+         "latitude" : 50.308513
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8002924.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Hof",
+         "postalCode" : "95028",
+         "street" : "Bahnhofsplatz"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "16",
+      "numberHandicapedPlaces" : "1",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 219772,
+         "duration" : "20min"
+      }, {
+         "id" : 219773,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 219774,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 219775,
+         "duration" : "1day",
+         "price" : 3.0
+      }, {
+         "id" : 219776,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219777,
+         "duration" : "1week",
+         "price" : 12.0
+      }, {
+         "id" : 219778,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219779,
+         "duration" : "1monthVendingMachine",
+         "price" : 35.0
+      }, {
+         "id" : 219780,
+         "duration" : "1monthLongTerm",
+         "price" : 35.0
+      }, {
+         "id" : 219781,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100146,
+      "title" : "Holzkirchen P1 Bahnhof Holzkirchen Parktaschen",
+      "station" : {
+         "id" : 2888,
+         "name" : "Holzkirchen"
+      },
+      "label" : "P1",
+      "spaceNumber" : "431",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Kurzzeitparkplätze",
+      "nameDisplay" : "Bahnhof Holzkirchen Parktaschen",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 11.697462,
+         "latitude" : 47.883153
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8002980.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Holzkirchen",
+         "postalCode" : "83607",
+         "street" : "Bahnhofplatz"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "8",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "10 Min.",
+         "tariffMaxParkingTimeEn" : "Max. 1 hour",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Stunde",
+         "tariffFreeParkingTimeEn" : "10 mins.",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219782,
+         "duration" : "20min"
+      }, {
+         "id" : 219783,
+         "duration" : "30min"
+      }, {
+         "id" : 219784,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 219785,
+         "duration" : "1day"
+      }, {
+         "id" : 219786,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219787,
+         "duration" : "1week"
+      }, {
+         "id" : 219788,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219789,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219790,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219791,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100147,
+      "title" : "Holzkirchen P2 Bahnhof Holzkirchen Bahnhofplatz",
+      "station" : {
+         "id" : 2888,
+         "name" : "Holzkirchen"
+      },
+      "label" : "P2",
+      "spaceNumber" : "432",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Bahnhof Holzkirchen Bahnhofplatz",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 11.696217,
+         "latitude" : 47.884382
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8002980.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Holzkirchen",
+         "postalCode" : "83607",
+         "street" : "Bahnhofplatz"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "93",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219792,
+         "duration" : "20min"
+      }, {
+         "id" : 219793,
+         "duration" : "30min"
+      }, {
+         "id" : 219794,
+         "duration" : "1hour"
+      }, {
+         "id" : 219795,
+         "duration" : "1day",
+         "price" : 1.2
+      }, {
+         "id" : 219796,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219797,
+         "duration" : "1week",
+         "price" : 7.0
+      }, {
+         "id" : 219798,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219799,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219800,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219801,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100148,
+      "title" : "Holzkirchen P3 Bahnhof Holzkirchen Bahnhofplatz rechts",
+      "station" : {
+         "id" : 2888,
+         "name" : "Holzkirchen"
+      },
+      "label" : "P3",
+      "spaceNumber" : "433",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Bahnhof Holzkirchen Bahnhofplatz rechts",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 11.697174,
+         "latitude" : 47.883515
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8002980.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Holzkirchen",
+         "postalCode" : "83607",
+         "street" : "Bahnhofplatz"
+      },
+      "distance" : "100-149",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "97",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219802,
+         "duration" : "20min"
+      }, {
+         "id" : 219803,
+         "duration" : "30min"
+      }, {
+         "id" : 219804,
+         "duration" : "1hour"
+      }, {
+         "id" : 219805,
+         "duration" : "1day",
+         "price" : 1.2
+      }, {
+         "id" : 219806,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219807,
+         "duration" : "1week",
+         "price" : 7.0
+      }, {
+         "id" : 219808,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219809,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219810,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219811,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100149,
+      "title" : "Holzkirchen P4 Bahnhof Holzkirchen Bahnhofplatz links",
+      "station" : {
+         "id" : 2888,
+         "name" : "Holzkirchen"
+      },
+      "label" : "P4",
+      "spaceNumber" : "434",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Bahnhof Holzkirchen Bahnhofplatz links",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 11.695502,
+         "latitude" : 47.884899
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8002980.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Holzkirchen",
+         "postalCode" : "83607",
+         "street" : "Bahnhofplatz"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "40",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219812,
+         "duration" : "20min"
+      }, {
+         "id" : 219813,
+         "duration" : "30min"
+      }, {
+         "id" : 219814,
+         "duration" : "1hour"
+      }, {
+         "id" : 219815,
+         "duration" : "1day",
+         "price" : 1.2
+      }, {
+         "id" : 219816,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219817,
+         "duration" : "1week",
+         "price" : 7.0
+      }, {
+         "id" : 219818,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219819,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219820,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219821,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100150,
+      "title" : "Holzkirchen P5 Bahnhof Holzkirchen Otterfinger Weg",
+      "station" : {
+         "id" : 2888,
+         "name" : "Holzkirchen"
+      },
+      "label" : "P5",
+      "spaceNumber" : "442",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Dauerparkplatz Otterfinger Weg",
+      "nameDisplay" : "Bahnhof Holzkirchen Otterfinger Weg",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 11.695207,
+         "latitude" : 47.885524
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8002980.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Holzkirchen",
+         "postalCode" : "83607",
+         "street" : "Bahnhofplatz / Otterfinger Weg"
+      },
+      "distance" : "<50",
+      "facilityType" : "keine",
+      "facilityTypeEn" : "none",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "72",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffSpecialEn" : "Without time-based or unlimited ride pass: Month 44.00",
+         "tariffSpecial" : "Ohne Zeitfahrkarte: Monat 44,00",
+         "tariffFreeParkingTimeEn" : "nein"
+      },
+      "tariffPrices" : [ {
+         "id" : 219822,
+         "duration" : "20min"
+      }, {
+         "id" : 219823,
+         "duration" : "30min"
+      }, {
+         "id" : 219824,
+         "duration" : "1hour"
+      }, {
+         "id" : 219825,
+         "duration" : "1day"
+      }, {
+         "id" : 219826,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219827,
+         "duration" : "1week"
+      }, {
+         "id" : 219828,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219829,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219830,
+         "duration" : "1monthLongTerm",
+         "price" : 22.0
+      }, {
+         "id" : 219831,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100151,
+      "title" : "Holzkirchen P6 Bahnhof Holzkirchen Am Ladehof",
+      "station" : {
+         "id" : 2888,
+         "name" : "Holzkirchen"
+      },
+      "label" : "P6",
+      "spaceNumber" : "435",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Dauerparkplatz Ladehof",
+      "nameDisplay" : "Bahnhof Holzkirchen Am Ladehof",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 11.695901,
+         "latitude" : 47.886298
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8002980.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Holzkirchen",
+         "postalCode" : "83607",
+         "street" : "Am Ladehof"
+      },
+      "distance" : "50-99",
+      "facilityType" : "keine",
+      "facilityTypeEn" : "none",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "28",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffSpecialEn" : "Without time-based or unlimited ride pass: Month 44.00",
+         "tariffSpecial" : "Ohne Zeitfahrkarte: Monat 44,00",
+         "tariffFreeParkingTimeEn" : "nein"
+      },
+      "tariffPrices" : [ {
+         "id" : 219832,
+         "duration" : "20min"
+      }, {
+         "id" : 219833,
+         "duration" : "30min"
+      }, {
+         "id" : 219834,
+         "duration" : "1hour"
+      }, {
+         "id" : 219835,
+         "duration" : "1day"
+      }, {
+         "id" : 219836,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219837,
+         "duration" : "1week"
+      }, {
+         "id" : 219838,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219839,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219840,
+         "duration" : "1monthLongTerm",
+         "price" : 22.0
+      }, {
+         "id" : 219841,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100152,
+      "title" : "Holzkirchen P7 Bahnhof Holzkirchen Erlkamer Str. Ladeh.",
+      "station" : {
+         "id" : 2888,
+         "name" : "Holzkirchen"
+      },
+      "label" : "P7",
+      "spaceNumber" : "443",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Bahnhof Holzkirchen Erlkamer Str. Ladeh.",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 11.695998,
+         "latitude" : 47.886417
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8002980.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Holzkirchen",
+         "postalCode" : "83607",
+         "street" : "Am Ladehof / Erlkamer Straße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "89",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219842,
+         "duration" : "20min"
+      }, {
+         "id" : 219843,
+         "duration" : "30min"
+      }, {
+         "id" : 219844,
+         "duration" : "1hour"
+      }, {
+         "id" : 219845,
+         "duration" : "1day",
+         "price" : 1.2
+      }, {
+         "id" : 219846,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219847,
+         "duration" : "1week",
+         "price" : 7.0
+      }, {
+         "id" : 219848,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219849,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219850,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219851,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100153,
+      "title" : "Homburg (Saar) Hbf P1 Parkplatz Homburg (Saar) Hbf Bahnhofspl.",
+      "station" : {
+         "id" : 2892,
+         "name" : "Homburg (Saar) Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "100",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Homburg (Saar) Hbf Bahnhofspl.",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 7.33748,
+         "latitude" : 49.327386
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000176.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Homburg an der Saar",
+         "postalCode" : "66424",
+         "street" : "Bahnhofsplatz"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "48",
+      "numberHandicapedPlaces" : "4",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "450",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 9 days or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 9 Tage oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219852,
+         "duration" : "20min"
+      }, {
+         "id" : 219853,
+         "duration" : "30min",
+         "price" : 0.7
+      }, {
+         "id" : 219854,
+         "duration" : "1hour",
+         "price" : 1.4
+      }, {
+         "id" : 219855,
+         "duration" : "1day",
+         "price" : 5.6
+      }, {
+         "id" : 219856,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219857,
+         "duration" : "1week",
+         "price" : 28.0
+      }, {
+         "id" : 219858,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219859,
+         "duration" : "1monthVendingMachine",
+         "price" : 40.0
+      }, {
+         "id" : 219860,
+         "duration" : "1monthLongTerm",
+         "price" : 40.0
+      }, {
+         "id" : 219861,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100154,
+      "title" : "Homburg (Saar) Hbf P2 Parkplatz Homburg (Saar) Hbf rechts",
+      "station" : {
+         "id" : 2892,
+         "name" : "Homburg (Saar) Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "99",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Homburg (Saar) Hbf rechts",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 7.338113,
+         "latitude" : 49.328012
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000176.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Homburg an der Saar",
+         "postalCode" : "66424",
+         "street" : "Bahnhofsplatz"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "34",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "400",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 9 days or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 9 Tage oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219862,
+         "duration" : "20min"
+      }, {
+         "id" : 219863,
+         "duration" : "30min",
+         "price" : 0.5
+      }, {
+         "id" : 219864,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 219865,
+         "duration" : "1day",
+         "price" : 4.5
+      }, {
+         "id" : 219866,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219867,
+         "duration" : "1week",
+         "price" : 22.5
+      }, {
+         "id" : 219868,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219869,
+         "duration" : "1monthVendingMachine",
+         "price" : 35.0
+      }, {
+         "id" : 219870,
+         "duration" : "1monthLongTerm",
+         "price" : 35.0
+      }, {
+         "id" : 219871,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100155,
+      "title" : "Homburg (Saar) Hbf P3 Parkplatz Homburg (Saar) Hbf links",
+      "station" : {
+         "id" : 2892,
+         "name" : "Homburg (Saar) Hbf"
+      },
+      "label" : "P3",
+      "spaceNumber" : "101",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Homburg (Saar) Hbf links",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 7.336214,
+         "latitude" : 49.326868
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000176.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Homburg an der Saar",
+         "postalCode" : "66424",
+         "street" : "Güterbahnhofstraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "91",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "450",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "ja"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 9 days or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 9 Tage oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219872,
+         "duration" : "20min"
+      }, {
+         "id" : 219873,
+         "duration" : "30min",
+         "price" : 0.5
+      }, {
+         "id" : 219874,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 219875,
+         "duration" : "1day",
+         "price" : 4.5
+      }, {
+         "id" : 219876,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219877,
+         "duration" : "1week",
+         "price" : 22.5
+      }, {
+         "id" : 219878,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219879,
+         "duration" : "1monthVendingMachine",
+         "price" : 35.0
+      }, {
+         "id" : 219880,
+         "duration" : "1monthLongTerm",
+         "price" : 35.0
+      }, {
+         "id" : 219881,
+         "duration" : "1monthReservation",
+         "price" : 50.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100156,
+      "title" : "Husum P1 Parkplatz Bahnhof Husum",
+      "station" : {
+         "id" : 2953,
+         "name" : "Husum"
+      },
+      "label" : "P1",
+      "spaceNumber" : "102",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Husum",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.053282,
+         "latitude" : 54.472588
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000181.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Husum",
+         "postalCode" : "25813",
+         "street" : "Poggenburgstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "42",
+      "numberHandicapedPlaces" : "2",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks from the parking ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 219882,
+         "duration" : "20min"
+      }, {
+         "id" : 219883,
+         "duration" : "30min"
+      }, {
+         "id" : 219884,
+         "duration" : "1hour",
+         "price" : 1.5
+      }, {
+         "id" : 219885,
+         "duration" : "1day",
+         "price" : 6.5
+      }, {
+         "id" : 219886,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219887,
+         "duration" : "1week",
+         "price" : 32.5
+      }, {
+         "id" : 219888,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219889,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219890,
+         "duration" : "1monthLongTerm",
+         "price" : 35.0
+      }, {
+         "id" : 219891,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100157,
+      "title" : "Kaiserslautern Hbf P1 Parkplatz Kaiserslautern Hbf",
+      "station" : {
+         "id" : 3082,
+         "name" : "Kaiserslautern Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "104",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Kiss&Ride-Parkplatz Hauptbahnhof",
+      "nameDisplay" : "Parkplatz Kaiserslautern Hbf",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 7.769379,
+         "latitude" : 49.435537
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000189.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Kaiserslautern",
+         "postalCode" : "67663",
+         "street" : "Zollamtstraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "41",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "280",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "15 Min.",
+         "tariffMaxParkingTimeEn" : "Max. 1 day",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Tag",
+         "tariffFreeParkingTimeEn" : "15 mins.",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219892,
+         "duration" : "20min"
+      }, {
+         "id" : 219893,
+         "duration" : "30min"
+      }, {
+         "id" : 219894,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 219895,
+         "duration" : "1day",
+         "price" : 6.0
+      }, {
+         "id" : 219896,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219897,
+         "duration" : "1week"
+      }, {
+         "id" : 219898,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219899,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219900,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219901,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100158,
+      "title" : "Kaiserslautern Hbf P2 Kaiserslautern Hbf P2 Park+Ride-Parkhaus",
+      "station" : {
+         "id" : 3082,
+         "name" : "Kaiserslautern Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "103",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Park+Ride-Parkhaus Hauptbahnhof",
+      "nameDisplay" : "Kaiserslautern Hbf P2 Park+Ride-Parkhaus",
+      "spaceType" : "Parkhaus",
+      "spaceTypeEn" : "Multi storey car park",
+      "spaceTypeName" : "Parkhaus",
+      "geoLocation" : {
+         "longitude" : 7.770361,
+         "latitude" : 49.435754
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000189.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Kaiserslautern",
+         "postalCode" : "67663",
+         "street" : "Zollamtstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "359",
+      "numberHandicapedPlaces" : "4",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "264",
+         "clearanceHeight" : "200",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : true,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffDiscount" : "Bonierung im DB Reisezentrum und an der DB Information. Bitte beachten Sie die jeweiligen Öffnungszeiten. Rabattierung mit BahnCard direkt am Kassenautomaten.",
+         "tariffFreeParkingTime" : "nein",
+         "tariffSpecialEn" : "Monthly tariff applies only to public transport customers. ",
+         "tariffSpecial" : "Monatstarif gilt nur für ÖPNV-Kunden",
+         "tariffDiscountEn" : "Reduction from the DB Information and the DB Reisezentrum (travel centre). Please note the respective opening hours. BahnCard discount available directly at the pay station. ",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA), P Card",
+         "tariffPaymentCustomerCards" : "P Card",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA), P Card"
+      },
+      "tariffPrices" : [ {
+         "id" : 219902,
+         "duration" : "20min"
+      }, {
+         "id" : 219903,
+         "duration" : "30min"
+      }, {
+         "id" : 219904,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 219905,
+         "duration" : "1day",
+         "price" : 6.0
+      }, {
+         "id" : 219906,
+         "duration" : "1dayDiscount",
+         "price" : 5.0
+      }, {
+         "id" : 219907,
+         "duration" : "1week"
+      }, {
+         "id" : 219908,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219909,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219910,
+         "duration" : "1monthLongTerm",
+         "price" : 44.0
+      }, {
+         "id" : 219911,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100160,
+      "title" : "Karlsruhe Hbf P4 Vorplatz Karlsruhe Hbf",
+      "station" : {
+         "id" : 3107,
+         "name" : "Karlsruhe Hbf"
+      },
+      "label" : "P4",
+      "spaceNumber" : "105",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Vorplatz Karlsruhe Hbf",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.401718,
+         "latitude" : 48.994524
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000191.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Karlsruhe",
+         "postalCode" : "76137",
+         "street" : "Bahnhofsplatz"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "26",
+      "numberHandicapedPlaces" : "1",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Woche",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219912,
+         "duration" : "20min"
+      }, {
+         "id" : 219913,
+         "duration" : "30min",
+         "price" : 1.0
+      }, {
+         "id" : 219914,
+         "duration" : "1hour",
+         "price" : 2.0
+      }, {
+         "id" : 219915,
+         "duration" : "1day",
+         "price" : 8.0
+      }, {
+         "id" : 219916,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219917,
+         "duration" : "1week",
+         "price" : 40.0
+      }, {
+         "id" : 219918,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219919,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219920,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219921,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100161,
+      "title" : "Karlsruhe Hbf P5 Karlsruhe Hbf Victor-Gollancz-Str.",
+      "station" : {
+         "id" : 3107,
+         "name" : "Karlsruhe Hbf"
+      },
+      "label" : "P5",
+      "spaceNumber" : "107",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Karlsruhe Hbf Victor-Gollancz-Str.",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.397601,
+         "latitude" : 48.993196
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000191.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Karlsruhe",
+         "postalCode" : "76137",
+         "street" : "Victor-Gollancz-Straße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "60",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks from the parking ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffSpecialEn" : "2 weeks: 45.00",
+         "tariffSpecial" : "2 Wochen: 45,00",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219922,
+         "duration" : "20min"
+      }, {
+         "id" : 219923,
+         "duration" : "30min",
+         "price" : 1.0
+      }, {
+         "id" : 219924,
+         "duration" : "1hour",
+         "price" : 2.0
+      }, {
+         "id" : 219925,
+         "duration" : "1day",
+         "price" : 8.0
+      }, {
+         "id" : 219926,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219927,
+         "duration" : "1week",
+         "price" : 32.0
+      }, {
+         "id" : 219928,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219929,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219930,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219931,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100162,
+      "title" : "Karlsruhe Hbf P7 Parkplatz Karlsruhe Hbf Schwarzwaldstr.",
+      "station" : {
+         "id" : 3107,
+         "name" : "Karlsruhe Hbf"
+      },
+      "label" : "P7",
+      "spaceNumber" : "108",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Karlsruhe Hbf Schwarzwaldstr.",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.397846,
+         "latitude" : 48.991671
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000191.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Karlsruhe",
+         "postalCode" : "76137",
+         "street" : "Schwarzwaldstraße / Hinterm Hauptbahnhof"
+      },
+      "distance" : ">250",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "38",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks from the parking ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 743528,
+         "duration" : "20min"
+      }, {
+         "id" : 743529,
+         "duration" : "30min",
+         "price" : 0.5
+      }, {
+         "id" : 743530,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 743531,
+         "duration" : "1day",
+         "price" : 4.2
+      }, {
+         "id" : 743532,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 743533,
+         "duration" : "1week",
+         "price" : 21.0
+      }, {
+         "id" : 743534,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 743535,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 743536,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 743537,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100164,
+      "title" : "Karlsruhe-Durlach P1 Parkplatz Bahnhof Karlsruhe-Durlach",
+      "station" : {
+         "id" : 3109,
+         "name" : "Karlsruhe-Durlach"
+      },
+      "label" : "P1",
+      "spaceNumber" : "244",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Karlsruhe-Durlach",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.463388,
+         "latitude" : 49.002023
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8003184.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Karlsruhe",
+         "postalCode" : "76228",
+         "street" : "Pfinzstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "11",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Woche",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219952,
+         "duration" : "20min"
+      }, {
+         "id" : 219953,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 219954,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 219955,
+         "duration" : "1day",
+         "price" : 3.0
+      }, {
+         "id" : 219956,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219957,
+         "duration" : "1week",
+         "price" : 15.0
+      }, {
+         "id" : 219958,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219959,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219960,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 219961,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100165,
+      "title" : "Kassel Hbf P2 Parkplatz Kassel Hbf Südseite",
+      "station" : {
+         "id" : 3124,
+         "name" : "Kassel Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "110",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Kassel Hbf Südseite",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.488421,
+         "latitude" : 51.317553
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000193.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Kassel",
+         "postalCode" : "34117",
+         "street" : "Franz-Ulrich-Straße"
+      },
+      "distance" : "100-149",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "67",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "clearanceHeight" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks from the parking ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffSpecialEn" : "2 weeks: 40.00",
+         "tariffSpecial" : "2 Wochen: 40,00",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219962,
+         "duration" : "20min"
+      }, {
+         "id" : 219963,
+         "duration" : "30min",
+         "price" : 0.5
+      }, {
+         "id" : 219964,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 219965,
+         "duration" : "1day",
+         "price" : 5.0
+      }, {
+         "id" : 219966,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219967,
+         "duration" : "1week",
+         "price" : 25.0
+      }, {
+         "id" : 219968,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219969,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219970,
+         "duration" : "1monthLongTerm",
+         "price" : 70.0
+      }, {
+         "id" : 219971,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100166,
+      "title" : "Kassel Hbf P3 Parkplatz Kassel Hbf Südseite hinten",
+      "station" : {
+         "id" : 3124,
+         "name" : "Kassel Hbf"
+      },
+      "label" : "P3",
+      "spaceNumber" : "230",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Kassel Hbf Südseite hinten",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.483007,
+         "latitude" : 51.318436
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000193.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Kassel",
+         "postalCode" : "34117",
+         "street" : "Franz-Ulrich-Straße"
+      },
+      "distance" : "150-200",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "105",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "500",
+         "clearanceHeight" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks from the parking ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffSpecialEn" : "2 weeks: 35.00",
+         "tariffSpecial" : "2 Wochen: 35,00",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219972,
+         "duration" : "20min"
+      }, {
+         "id" : 219973,
+         "duration" : "30min",
+         "price" : 0.5
+      }, {
+         "id" : 219974,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 219975,
+         "duration" : "1day",
+         "price" : 4.0
+      }, {
+         "id" : 219976,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219977,
+         "duration" : "1week",
+         "price" : 20.0
+      }, {
+         "id" : 219978,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219979,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219980,
+         "duration" : "1monthLongTerm",
+         "price" : 60.0
+      }, {
+         "id" : 219981,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100167,
+      "title" : "Kassel Hbf P4 Parkplatz Kassel Hbf Südseite vorn",
+      "station" : {
+         "id" : 3124,
+         "name" : "Kassel Hbf"
+      },
+      "label" : "P4",
+      "spaceNumber" : "338",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Kassel Hbf Südseite vorn",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.48907,
+         "latitude" : 51.317674
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000193.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Kassel",
+         "postalCode" : "34117",
+         "street" : "Franz-Ulrich-Straße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "53",
+      "numberHandicapedPlaces" : "1",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "500",
+         "clearanceHeight" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks from the parking ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffSpecialEn" : "2 weeks: 40.00",
+         "tariffSpecial" : "2 Wochen: 40,00",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 219982,
+         "duration" : "20min"
+      }, {
+         "id" : 219983,
+         "duration" : "30min",
+         "price" : 0.5
+      }, {
+         "id" : 219984,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 219985,
+         "duration" : "1day",
+         "price" : 5.0
+      }, {
+         "id" : 219986,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219987,
+         "duration" : "1week",
+         "price" : 25.0
+      }, {
+         "id" : 219988,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219989,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 219990,
+         "duration" : "1monthLongTerm",
+         "price" : 70.0
+      }, {
+         "id" : 219991,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100168,
+      "title" : "Kassel Hbf P5 Parkplatz Kassel Hbf Innenhof",
+      "station" : {
+         "id" : 3124,
+         "name" : "Kassel Hbf"
+      },
+      "label" : "P5",
+      "spaceNumber" : "339",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Innenhof",
+      "nameDisplay" : "Parkplatz Kassel Hbf Innenhof",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.488235,
+         "latitude" : 51.319452
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000193.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Kassel",
+         "postalCode" : "34117",
+         "street" : "Joseph-Beuys-Straße"
+      },
+      "distance" : "<50",
+      "facilityType" : "keine",
+      "facilityTypeEn" : "none",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "13",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "240",
+         "clearanceHeight" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffFreeParkingTimeEn" : "nein"
+      },
+      "tariffPrices" : [ {
+         "id" : 219992,
+         "duration" : "20min"
+      }, {
+         "id" : 219993,
+         "duration" : "30min"
+      }, {
+         "id" : 219994,
+         "duration" : "1hour"
+      }, {
+         "id" : 219995,
+         "duration" : "1day"
+      }, {
+         "id" : 219996,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 219997,
+         "duration" : "1week"
+      }, {
+         "id" : 219998,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 219999,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220000,
+         "duration" : "1monthLongTerm",
+         "price" : 70.0
+      }, {
+         "id" : 220001,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100169,
+      "title" : "Kassel-Wilhelmshöhe P1 Kassel Wilhelmshöhe P1 Parkplatz",
+      "station" : {
+         "id" : 3127,
+         "name" : "Kassel-Wilhelmshöhe"
+      },
+      "label" : "P1",
+      "spaceNumber" : "111",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Bahnhof Kassel-Wilhelmshöhe",
+      "nameDisplay" : "Kassel Wilhelmshöhe P1 Parkplatz",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.445558,
+         "latitude" : 51.312477
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8003200.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Kassel",
+         "postalCode" : "34131",
+         "street" : "Bertha-von-Suttner-Straße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "26",
+      "numberHandicapedPlaces" : "3",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "280",
+         "clearanceHeight" : "320",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : true,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : true,
+         "isDiscountDbParkAndRail" : true,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffDiscount" : "Bonierung bei der Parkhausaufsicht, im DB Reisezentrum und an der DB Information. Rabattierung mit BahnCard direkt am Kassenautomaten.",
+         "tariffFreeParkingTime" : "nein",
+         "tariffDiscountEn" : "Reduction from the car park supervisor, at the DB Information and the DB Reisezentrum (travel centre). BahnCard discount available directly at the pay station.",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA), EC-Karte",
+         "tariffPointOfSale" : "Park&Rail-Karten erhältlich an allen Verkaufsstellen der Deutschen Bahn (außer Internet).",
+         "tariffPointOfSaleEn" : "Park&Rail cards available from all Deutsche Bahn points of sale (except online).  ",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA), EC-Card"
+      },
+      "tariffPrices" : [ {
+         "id" : 220002,
+         "duration" : "20min"
+      }, {
+         "id" : 220003,
+         "duration" : "30min"
+      }, {
+         "id" : 220004,
+         "duration" : "1hour",
+         "price" : 1.5
+      }, {
+         "id" : 220005,
+         "duration" : "1day",
+         "price" : 19.0
+      }, {
+         "id" : 220006,
+         "duration" : "1dayDiscount",
+         "price" : 16.0
+      }, {
+         "id" : 220007,
+         "duration" : "1week"
+      }, {
+         "id" : 220008,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220009,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220010,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 220011,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100170,
+      "title" : "Kassel-Wilhelmshöhe P2 Kassel Wilhelmshöhe P2 Parkdeck",
+      "station" : {
+         "id" : 3127,
+         "name" : "Kassel-Wilhelmshöhe"
+      },
+      "label" : "P2",
+      "spaceNumber" : "437",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkdeck Bahnhof Kassel-Wilhelmshöhe",
+      "nameDisplay" : "Kassel Wilhelmshöhe P2 Parkdeck",
+      "spaceType" : "Parkdeck",
+      "spaceTypeEn" : "Parking deck",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.44757,
+         "latitude" : 51.311294
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8003200.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Kassel",
+         "postalCode" : "34131",
+         "street" : "Bertha-von-Suttner-Straße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "370",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : true,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : true,
+         "isDiscountDbParkAndRail" : true,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffDiscount" : "Bonierung bei der Parkhausaufsicht, im DB Reisezentrum und an der DB Information. Rabattierung mit BahnCard direkt am Kassenautomaten.",
+         "tariffFreeParkingTime" : "nein",
+         "tariffDiscountEn" : "Reduction from the car park supervisor, at the DB Information and the DB Reisezentrum (travel centre). BahnCard discount available directly at the pay station.",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA), EC-Karte",
+         "tariffPointOfSale" : "Park&Rail-Karten erhältlich an allen Verkaufsstellen der Deutschen Bahn (außer Internet).",
+         "tariffPointOfSaleEn" : "Park&Rail cards available from all Deutsche Bahn points of sale (except online).  ",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA), EC-Card"
+      },
+      "tariffPrices" : [ {
+         "id" : 220012,
+         "duration" : "20min"
+      }, {
+         "id" : 220013,
+         "duration" : "30min"
+      }, {
+         "id" : 220014,
+         "duration" : "1hour",
+         "price" : 1.5
+      }, {
+         "id" : 220015,
+         "duration" : "1day",
+         "price" : 19.0
+      }, {
+         "id" : 220016,
+         "duration" : "1dayDiscount",
+         "price" : 16.0
+      }, {
+         "id" : 220017,
+         "duration" : "1week"
+      }, {
+         "id" : 220018,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220019,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220020,
+         "duration" : "1monthLongTerm",
+         "price" : 130.0
+      }, {
+         "id" : 220021,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100171,
+      "title" : "Kassel-Wilhelmshöhe P3 Parkplatz Kassel-Wilhelmshöhe West",
+      "station" : {
+         "id" : 3127,
+         "name" : "Kassel-Wilhelmshöhe"
+      },
+      "label" : "P3",
+      "spaceNumber" : "340",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Kassel-Wilhelmshöhe West",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.446001,
+         "latitude" : 51.311637
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8003200.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Kassel",
+         "postalCode" : "34131",
+         "street" : "Bertha-von-Suttner-Straße"
+      },
+      "distance" : "100-149",
+      "facilityType" : "keine",
+      "facilityTypeEn" : "none",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "66",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "320",
+         "clearanceHeight" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffFreeParkingTimeEn" : "nein"
+      },
+      "tariffPrices" : [ {
+         "id" : 220022,
+         "duration" : "20min"
+      }, {
+         "id" : 220023,
+         "duration" : "30min"
+      }, {
+         "id" : 220024,
+         "duration" : "1hour"
+      }, {
+         "id" : 220025,
+         "duration" : "1day"
+      }, {
+         "id" : 220026,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220027,
+         "duration" : "1week"
+      }, {
+         "id" : 220028,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220029,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220030,
+         "duration" : "1monthLongTerm",
+         "price" : 95.0
+      }, {
+         "id" : 220031,
+         "duration" : "1monthReservation",
+         "price" : 130.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100179,
+      "title" : "Kempten (Allgäu) Hbf P1 Parkplatz Kempten Hbf Rückseite ",
+      "station" : {
+         "id" : 3155,
+         "name" : "Kempten (Allgäu) Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "112",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Kempten Hbf Rückseite ",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 10.318478,
+         "latitude" : 47.711846
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000197.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Kempten im Allgäu",
+         "postalCode" : "87435",
+         "street" : "Eicher Straße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "120",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceHeight" : "300",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220032,
+         "duration" : "20min"
+      }, {
+         "id" : 220033,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 220034,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 220035,
+         "duration" : "1day",
+         "price" : 2.0
+      }, {
+         "id" : 220036,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220037,
+         "duration" : "1week",
+         "price" : 10.0
+      }, {
+         "id" : 220038,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220039,
+         "duration" : "1monthVendingMachine",
+         "price" : 25.0
+      }, {
+         "id" : 220040,
+         "duration" : "1monthLongTerm",
+         "price" : 25.0
+      }, {
+         "id" : 220041,
+         "duration" : "1monthReservation",
+         "price" : 50.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100181,
+      "title" : "Kirchheim (Teck) P1 Parkplatz Bahnhof Kirchheim (Teck)",
+      "station" : {
+         "id" : 3194,
+         "name" : "Kirchheim (Teck)"
+      },
+      "label" : "P1",
+      "spaceNumber" : "291",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Kirchheim (Teck)",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.442324,
+         "latitude" : 48.645001
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8003280.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Kirchheim unter Teck",
+         "postalCode" : "73230",
+         "street" : "Schöllkopfstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "130",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220042,
+         "duration" : "20min"
+      }, {
+         "id" : 220043,
+         "duration" : "30min",
+         "price" : 0.55
+      }, {
+         "id" : 220044,
+         "duration" : "1hour",
+         "price" : 1.1
+      }, {
+         "id" : 220045,
+         "duration" : "1day",
+         "price" : 2.4
+      }, {
+         "id" : 220046,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220047,
+         "duration" : "1week",
+         "price" : 9.6
+      }, {
+         "id" : 220048,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220049,
+         "duration" : "1monthVendingMachine",
+         "price" : 22.0
+      }, {
+         "id" : 220050,
+         "duration" : "1monthLongTerm",
+         "price" : 22.0
+      }, {
+         "id" : 220051,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100182,
+      "title" : "Kirchheim (Teck) P2 Bahnhof Kirchheim Schöllkopfstraße",
+      "station" : {
+         "id" : 3194,
+         "name" : "Kirchheim (Teck)"
+      },
+      "label" : "P2",
+      "spaceNumber" : "343",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Bahnhof Kirchheim Schöllkopfstraße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.443475,
+         "latitude" : 48.645147
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8003280.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Kirchheim unter Teck",
+         "postalCode" : "73230",
+         "street" : "Schöllkopfstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "17",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 day",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Tag",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220052,
+         "duration" : "20min"
+      }, {
+         "id" : 220053,
+         "duration" : "30min",
+         "price" : 0.55
+      }, {
+         "id" : 220054,
+         "duration" : "1hour",
+         "price" : 1.1
+      }, {
+         "id" : 220055,
+         "duration" : "1day",
+         "price" : 3.3
+      }, {
+         "id" : 220056,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220057,
+         "duration" : "1week"
+      }, {
+         "id" : 220058,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220059,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220060,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 220061,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100183,
+      "title" : "Koblenz-Ehrenbreitstein P1 Bahnhof Koblenz-Ehrenbreitstein",
+      "station" : {
+         "id" : 3300,
+         "name" : "Koblenz-Ehrenbreitstein"
+      },
+      "label" : "P1",
+      "spaceNumber" : "423",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Bahnhof Koblenz-Ehrenbreitstein",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 7.610623,
+         "latitude" : 50.361916
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8003351.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Koblenz",
+         "postalCode" : "56077",
+         "street" : "Hofstraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "60",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220062,
+         "duration" : "20min"
+      }, {
+         "id" : 220063,
+         "duration" : "30min"
+      }, {
+         "id" : 220064,
+         "duration" : "1hour",
+         "price" : 0.6
+      }, {
+         "id" : 220065,
+         "duration" : "1day",
+         "price" : 2.2
+      }, {
+         "id" : 220066,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220067,
+         "duration" : "1week",
+         "price" : 11.0
+      }, {
+         "id" : 220068,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220069,
+         "duration" : "1monthVendingMachine",
+         "price" : 30.0
+      }, {
+         "id" : 220070,
+         "duration" : "1monthLongTerm",
+         "price" : 30.0
+      }, {
+         "id" : 220071,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100173,
+      "title" : "Köln Hbf P2 Parkplatz Köln Hbf Maximinenstraße",
+      "station" : {
+         "id" : 3320,
+         "name" : "Köln Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "115",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Maximinenstraße",
+      "nameDisplay" : "Parkplatz Köln Hbf Maximinenstraße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 6.957985,
+         "latitude" : 50.944694
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000207.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Köln",
+         "postalCode" : "50668",
+         "street" : "Maximinenstraße"
+      },
+      "distance" : "100-149",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "84",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Woche",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220072,
+         "duration" : "20min"
+      }, {
+         "id" : 220073,
+         "duration" : "30min",
+         "price" : 2.0
+      }, {
+         "id" : 220074,
+         "duration" : "1hour",
+         "price" : 4.0
+      }, {
+         "id" : 220075,
+         "duration" : "1day",
+         "price" : 14.0
+      }, {
+         "id" : 220076,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220077,
+         "duration" : "1week",
+         "price" : 56.0
+      }, {
+         "id" : 220078,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220079,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220080,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 220081,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100174,
+      "title" : "Köln Hbf P3 Parkplatz Köln Hbf Domplatte",
+      "station" : {
+         "id" : 3320,
+         "name" : "Köln Hbf"
+      },
+      "label" : "P3",
+      "spaceNumber" : "113",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Domplatte",
+      "nameDisplay" : "Parkplatz Köln Hbf Domplatte",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 6.957199,
+         "latitude" : 50.942741
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000207.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Köln",
+         "postalCode" : "50668",
+         "street" : "Domprobst-Ketzer-Straße/An den Dominikanern"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "17",
+      "numberHandicapedPlaces" : "2",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 hour",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Stunde",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220082,
+         "duration" : "20min"
+      }, {
+         "id" : 220083,
+         "duration" : "30min",
+         "price" : 3.0
+      }, {
+         "id" : 220084,
+         "duration" : "1hour",
+         "price" : 6.0
+      }, {
+         "id" : 220085,
+         "duration" : "1day"
+      }, {
+         "id" : 220086,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220087,
+         "duration" : "1week"
+      }, {
+         "id" : 220088,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220089,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220090,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 220091,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100175,
+      "title" : "Köln Hbf P5 Parkplatz Köln Hbf Trankgasse",
+      "station" : {
+         "id" : 3320,
+         "name" : "Köln Hbf"
+      },
+      "label" : "P5",
+      "spaceNumber" : "114",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Trankgasse",
+      "nameDisplay" : "Parkplatz Köln Hbf Trankgasse",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 6.961333,
+         "latitude" : 50.941869
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000207.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Köln",
+         "postalCode" : "50668",
+         "street" : "Trankgasse"
+      },
+      "distance" : "100-149",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "18",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 3 days",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 3 Tage",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220092,
+         "duration" : "20min"
+      }, {
+         "id" : 220093,
+         "duration" : "30min",
+         "price" : 2.0
+      }, {
+         "id" : 220094,
+         "duration" : "1hour",
+         "price" : 4.0
+      }, {
+         "id" : 220095,
+         "duration" : "1day",
+         "price" : 15.0
+      }, {
+         "id" : 220096,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220097,
+         "duration" : "1week"
+      }, {
+         "id" : 220098,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220099,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220100,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 220101,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100176,
+      "title" : "Köln Hbf P6 Parkplatz Köln Hbf Am Alten Ufer",
+      "station" : {
+         "id" : 3320,
+         "name" : "Köln Hbf"
+      },
+      "label" : "P6",
+      "spaceNumber" : "285",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Am Alten Ufer",
+      "nameDisplay" : "Parkplatz Köln Hbf Am Alten Ufer",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 6.961405,
+         "latitude" : 50.942182
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000207.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Köln",
+         "postalCode" : "50667",
+         "street" : "Am Alten Ufer/Kostgasse"
+      },
+      "distance" : "100-149",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "95",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220102,
+         "duration" : "20min"
+      }, {
+         "id" : 220103,
+         "duration" : "30min",
+         "price" : 2.0
+      }, {
+         "id" : 220104,
+         "duration" : "1hour",
+         "price" : 4.0
+      }, {
+         "id" : 220105,
+         "duration" : "1day",
+         "price" : 15.0
+      }, {
+         "id" : 220106,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220107,
+         "duration" : "1week",
+         "price" : 60.0
+      }, {
+         "id" : 220108,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220109,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220110,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 220111,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100177,
+      "title" : "Köln-Mülheim P1 Parkplatz Bahnhof Köln-Mülheim links",
+      "station" : {
+         "id" : 3336,
+         "name" : "Köln-Mülheim"
+      },
+      "label" : "P1",
+      "spaceNumber" : "355",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Köln-Mülheim links",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 7.01247,
+         "latitude" : 50.957949
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000209.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Köln",
+         "postalCode" : "51066",
+         "street" : "Montanusstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "24",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220122,
+         "duration" : "20min"
+      }, {
+         "id" : 220123,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 220124,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 220125,
+         "duration" : "1day",
+         "price" : 3.0
+      }, {
+         "id" : 220126,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220127,
+         "duration" : "1week",
+         "price" : 15.0
+      }, {
+         "id" : 220128,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220129,
+         "duration" : "1monthVendingMachine",
+         "price" : 40.0
+      }, {
+         "id" : 220130,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 220131,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100178,
+      "title" : "Köln-Mülheim P2 Parkplatz Bahnhof Köln-Mülheim rechts",
+      "station" : {
+         "id" : 3336,
+         "name" : "Köln-Mülheim"
+      },
+      "label" : "P2",
+      "spaceNumber" : "116",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Köln-Mülheim rechts",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 7.012253,
+         "latitude" : 50.957247
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000209.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Köln",
+         "postalCode" : "51065",
+         "street" : "Montanusstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "13",
+      "numberHandicapedPlaces" : "2",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "ja"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220112,
+         "duration" : "20min"
+      }, {
+         "id" : 220113,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 220114,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 220115,
+         "duration" : "1day",
+         "price" : 3.0
+      }, {
+         "id" : 220116,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220117,
+         "duration" : "1week",
+         "price" : 15.0
+      }, {
+         "id" : 220118,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220119,
+         "duration" : "1monthVendingMachine",
+         "price" : 40.0
+      }, {
+         "id" : 220120,
+         "duration" : "1monthLongTerm",
+         "price" : 40.0
+      }, {
+         "id" : 220121,
+         "duration" : "1monthReservation",
+         "price" : 80.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100184,
+      "title" : "Korntal P1 Parkplatz Bahnhof Korntal",
+      "station" : {
+         "id" : 3377,
+         "name" : "Korntal"
+      },
+      "label" : "P1",
+      "spaceNumber" : "319",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Korntal",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.12057,
+         "latitude" : 48.826538
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8003409.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Korntal",
+         "postalCode" : "70825",
+         "street" : "Ladestraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "70",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 10 days or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 10 Tage oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220132,
+         "duration" : "20min"
+      }, {
+         "id" : 220133,
+         "duration" : "30min",
+         "price" : 0.55
+      }, {
+         "id" : 220134,
+         "duration" : "1hour",
+         "price" : 1.1
+      }, {
+         "id" : 220135,
+         "duration" : "1day",
+         "price" : 2.2
+      }, {
+         "id" : 220136,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220137,
+         "duration" : "1week",
+         "price" : 8.8
+      }, {
+         "id" : 220138,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220139,
+         "duration" : "1monthVendingMachine",
+         "price" : 16.5
+      }, {
+         "id" : 220140,
+         "duration" : "1monthLongTerm",
+         "price" : 16.5
+      }, {
+         "id" : 220141,
+         "duration" : "1monthReservation",
+         "price" : 25.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100186,
+      "title" : "Kulmbach P1 Parkplatz Bahnhof Kulmbach",
+      "station" : {
+         "id" : 3458,
+         "name" : "Kulmbach"
+      },
+      "label" : "P1",
+      "spaceNumber" : "249",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Kulmbach",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 11.453692,
+         "latitude" : 50.109951
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8003476.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Kulmbach",
+         "postalCode" : "95326",
+         "street" : "Heinrich-von-Stephan-Straße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "55",
+      "numberHandicapedPlaces" : "2",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220142,
+         "duration" : "20min"
+      }, {
+         "id" : 220143,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 220144,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 220145,
+         "duration" : "1day",
+         "price" : 2.5
+      }, {
+         "id" : 220146,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220147,
+         "duration" : "1week",
+         "price" : 12.5
+      }, {
+         "id" : 220148,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220149,
+         "duration" : "1monthVendingMachine",
+         "price" : 28.0
+      }, {
+         "id" : 220150,
+         "duration" : "1monthLongTerm",
+         "price" : 28.0
+      }, {
+         "id" : 220151,
+         "duration" : "1monthReservation",
+         "price" : 40.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100187,
+      "title" : "Landau (Pfalz) Hbf P2 Parkplatz Landau Hbf Maximilianstraße",
+      "station" : {
+         "id" : 3505,
+         "name" : "Landau (Pfalz) Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "257",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Landau Hbf Maximilianstraße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.125647,
+         "latitude" : 49.199252
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000216.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Landau",
+         "postalCode" : "76829",
+         "street" : "Maximilianstraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "30",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220152,
+         "duration" : "20min"
+      }, {
+         "id" : 220153,
+         "duration" : "30min"
+      }, {
+         "id" : 220154,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 220155,
+         "duration" : "1day",
+         "price" : 2.5
+      }, {
+         "id" : 220156,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220157,
+         "duration" : "1week",
+         "price" : 12.5
+      }, {
+         "id" : 220158,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220159,
+         "duration" : "1monthVendingMachine",
+         "price" : 38.0
+      }, {
+         "id" : 220160,
+         "duration" : "1monthLongTerm",
+         "price" : 38.0
+      }, {
+         "id" : 220161,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100190,
+      "title" : "Lichtenfels P1 Parkplatz Bahnhof Lichtenfels am Bahnhof",
+      "station" : {
+         "id" : 3700,
+         "name" : "Lichtenfels"
+      },
+      "label" : "P1",
+      "spaceNumber" : "117",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Lichtenfels am Bahnhof",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 11.059114,
+         "latitude" : 50.145509
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000228.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Lichtenfels",
+         "postalCode" : "95192",
+         "street" : "Bahnhofplatz/Conrad-Wagner-Straße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "10",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 9 days or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 9 Tage oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220162,
+         "duration" : "20min"
+      }, {
+         "id" : 220163,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 220164,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 220165,
+         "duration" : "1day",
+         "price" : 5.2
+      }, {
+         "id" : 220166,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220167,
+         "duration" : "1week",
+         "price" : 20.8
+      }, {
+         "id" : 220168,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220169,
+         "duration" : "1monthVendingMachine",
+         "price" : 33.0
+      }, {
+         "id" : 220170,
+         "duration" : "1monthLongTerm",
+         "price" : 33.0
+      }, {
+         "id" : 220171,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100191,
+      "title" : "Lichtenfels P2 Parkplatz Bahnhof Lichtenfels am Gleis",
+      "station" : {
+         "id" : 3700,
+         "name" : "Lichtenfels"
+      },
+      "label" : "P2",
+      "spaceNumber" : "118",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Lichtenfels am Gleis",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 11.060469,
+         "latitude" : 50.146683
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000228.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Lichtenfels",
+         "postalCode" : "95192",
+         "street" : "Bgm.-Dr.-Hauptmann-Ring/Zweigstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "46",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 9 days or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 9 Tage oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220172,
+         "duration" : "20min"
+      }, {
+         "id" : 220173,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 220174,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 220175,
+         "duration" : "1day",
+         "price" : 5.2
+      }, {
+         "id" : 220176,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220177,
+         "duration" : "1week",
+         "price" : 20.8
+      }, {
+         "id" : 220178,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220179,
+         "duration" : "1monthVendingMachine",
+         "price" : 33.0
+      }, {
+         "id" : 220180,
+         "duration" : "1monthLongTerm",
+         "price" : 33.0
+      }, {
+         "id" : 220181,
+         "duration" : "1monthReservation",
+         "price" : 50.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100192,
+      "title" : "Limburg Süd P1 Parkplatz Bahnhof Limburg Süd",
+      "station" : {
+         "id" : 3723,
+         "name" : "Limburg Süd"
+      },
+      "label" : "P1",
+      "spaceNumber" : "362",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Limburg Süd",
+      "nameDisplay" : "Parkplatz Bahnhof Limburg Süd",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.093938,
+         "latitude" : 50.383503
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8003680.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Limburg an der Lahn",
+         "postalCode" : "65552",
+         "street" : "Londoner Straße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "306",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "clearanceHeight" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffSpecialEn" : "4 weeks ticket (28 days): 28.00. Limited seasonparkers'  monthly tariff for short distance public transport customers: 10.00 ",
+         "tariffMaxParkingTime" : "Max. 13 Tage oder 4-Wochen-Parkschein",
+         "tarifNotesEn" : "Contipark parking tickets are valid only in the surface car park. Parking tickets for the city's multi storey car park are not valid in this area. ",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffNotes" : "Parkscheine und Dauerparkkarten nur auf dem Parkplatz gültig. Parkkarten für das Parkhaus der Kreisstadt Limburg an der Lahn haben auf dieser Fläche keine Gültigkeit.",
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 13 days or four-weeks-ticket from the ticket machine",
+         "tariffSpecial" : "4-Wochen-Parkschein: 28,00; Sonderkontingent Dauerparken für ÖPNV-Kunden: 10,00 pro Monat",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220182,
+         "duration" : "20min"
+      }, {
+         "id" : 220183,
+         "duration" : "30min"
+      }, {
+         "id" : 220184,
+         "duration" : "1hour"
+      }, {
+         "id" : 220185,
+         "duration" : "1day",
+         "price" : 2.0
+      }, {
+         "id" : 220186,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220187,
+         "duration" : "1week",
+         "price" : 14.0
+      }, {
+         "id" : 220188,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220189,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220190,
+         "duration" : "1monthLongTerm",
+         "price" : 25.0
+      }, {
+         "id" : 220191,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100193,
+      "title" : "Lindau Hbf P1 Parkplatz Lindau Hbf",
+      "station" : {
+         "id" : 3727,
+         "name" : "Lindau Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "119",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Lindau Hbf",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.68095,
+         "latitude" : 47.543496
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000230.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Lindau",
+         "postalCode" : "88131",
+         "street" : "Bahnhof 1e"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "38",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 1 Woche",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 220192,
+         "duration" : "20min"
+      }, {
+         "id" : 220193,
+         "duration" : "30min"
+      }, {
+         "id" : 220194,
+         "duration" : "1hour",
+         "price" : 2.0
+      }, {
+         "id" : 220195,
+         "duration" : "1day",
+         "price" : 9.0
+      }, {
+         "id" : 220196,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220197,
+         "duration" : "1week",
+         "price" : 45.0
+      }, {
+         "id" : 220198,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220199,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220200,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 220201,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100188,
+      "title" : "Lübeck Hbf P1 Parkplatz Lübeck Hbf Beim Retteich",
+      "station" : {
+         "id" : 3807,
+         "name" : "Lübeck Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "290",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Beim Retteich",
+      "nameDisplay" : "Parkplatz Lübeck Hbf Beim Retteich",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 10.668625,
+         "latitude" : 53.865984
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000237.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Lübeck",
+         "postalCode" : "23558",
+         "street" : "Beim Retteich"
+      },
+      "distance" : "100-149",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "136",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220222,
+         "duration" : "20min"
+      }, {
+         "id" : 220223,
+         "duration" : "30min",
+         "price" : 0.5
+      }, {
+         "id" : 220224,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 220225,
+         "duration" : "1day",
+         "price" : 3.0
+      }, {
+         "id" : 220226,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220227,
+         "duration" : "1week",
+         "price" : 15.0
+      }, {
+         "id" : 220228,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220229,
+         "duration" : "1monthVendingMachine",
+         "price" : 70.0
+      }, {
+         "id" : 220230,
+         "duration" : "1monthLongTerm",
+         "price" : 70.0
+      }, {
+         "id" : 220231,
+         "duration" : "1monthReservation",
+         "price" : 100.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100189,
+      "title" : "Lübeck Hbf P2 Parkplatz Lübeck Hbf Am Güterbahnhof",
+      "station" : {
+         "id" : 3807,
+         "name" : "Lübeck Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "408",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Am Güterbahnhof",
+      "nameDisplay" : "Parkplatz Lübeck Hbf Am Güterbahnhof",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 10.667931,
+         "latitude" : 53.865656
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000237.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Lübeck",
+         "postalCode" : "23558",
+         "street" : "Am Güterbahnhof"
+      },
+      "distance" : "150-199",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "124",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220232,
+         "duration" : "20min"
+      }, {
+         "id" : 220233,
+         "duration" : "30min",
+         "price" : 0.5
+      }, {
+         "id" : 220234,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 220235,
+         "duration" : "1day",
+         "price" : 2.5
+      }, {
+         "id" : 220236,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220237,
+         "duration" : "1week",
+         "price" : 17.5
+      }, {
+         "id" : 220238,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220239,
+         "duration" : "1monthVendingMachine",
+         "price" : 70.0
+      }, {
+         "id" : 220240,
+         "duration" : "1monthLongTerm",
+         "price" : 70.0
+      }, {
+         "id" : 220241,
+         "duration" : "1monthReservation",
+         "price" : 100.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100194,
+      "title" : "Ludwigsburg P3 Bahnhof Ludwigsburg Leonberger Staße",
+      "station" : {
+         "id" : 3833,
+         "name" : "Ludwigsburg"
+      },
+      "label" : "P3",
+      "spaceNumber" : "386",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Park+Ride-Parkplatz",
+      "nameDisplay" : "Bahnhof Ludwigsburg Leonberger Staße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.187904,
+         "latitude" : 48.890562
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000235.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Ludwigsburg",
+         "postalCode" : "71638",
+         "street" : "Leonberger Straße"
+      },
+      "distance" : "250",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "60",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "outOfServiceText" : "",
+      "spaceInfo" : {
+         "clearanceWidth" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 3 days",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 3 Tage",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 311747,
+         "duration" : "20min"
+      }, {
+         "id" : 311748,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 311749,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 311750,
+         "duration" : "1day",
+         "price" : 4.0
+      }, {
+         "id" : 311751,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 311752,
+         "duration" : "1week"
+      }, {
+         "id" : 311753,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 311754,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 311755,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 311756,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100195,
+      "title" : "Ludwigshafen (Rhein) Hbf P1 Parkplatz Ludwigshafen (Rhein) Hbf",
+      "station" : {
+         "id" : 3837,
+         "name" : "Ludwigshafen (Rhein) Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "120",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Ludwigshafen (Rhein) Hbf",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.433783,
+         "latitude" : 49.475042
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000236.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Ludwigshafen",
+         "postalCode" : "67061",
+         "street" : "Richard-Dehmel-Straße"
+      },
+      "distance" : "200-250",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "190",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220212,
+         "duration" : "20min"
+      }, {
+         "id" : 220213,
+         "duration" : "30min",
+         "price" : 0.5
+      }, {
+         "id" : 220214,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 220215,
+         "duration" : "1day",
+         "price" : 1.5
+      }, {
+         "id" : 220216,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220217,
+         "duration" : "1week",
+         "price" : 7.5
+      }, {
+         "id" : 220218,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220219,
+         "duration" : "1monthVendingMachine",
+         "price" : 25.0
+      }, {
+         "id" : 220220,
+         "duration" : "1monthLongTerm",
+         "price" : 25.0
+      }, {
+         "id" : 220221,
+         "duration" : "1monthReservation",
+         "price" : 35.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100196,
+      "title" : "Magdeburg Hbf P1 Magdeburg Hbf P1 Parkgarage City Carré",
+      "station" : {
+         "id" : 3881,
+         "name" : "Magdeburg Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "400",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkgarage City Carré / Hauptbahnhof",
+      "nameDisplay" : "Magdeburg Hbf P1 Parkgarage City Carré",
+      "spaceType" : "Tiefgarage",
+      "spaceTypeEn" : "Underground car park",
+      "spaceTypeName" : "Tiefgarage",
+      "geoLocation" : {
+         "longitude" : 11.628524,
+         "latitude" : 52.129412
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8010224.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Magdeburg",
+         "postalCode" : "39104",
+         "street" : "Kantstraße 3",
+         "supplement" : "Einfahrt: Bahnhofstraße",
+         "supplementEn" : "Access via Bahnhofstraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "246",
+      "numberHandicapedPlaces" : "16",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "250",
+         "clearanceHeight" : "200",
+         "locationNightAccess" : "Nord - neben Kino, Süd - neben SWM",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffSpecialEn" : "2nd hour: 0.60, each additional hour: 1.00. 2017: Parking on Saturdays up to 4 hours max. is free of charge!",
+         "tariffSpecial" : "2. Stunde: 0,60, je weitere Stunde: 1,00. 2017: Parkvorgänge bis zu max. 4 Stunden sind an Samstagen kostenlos!",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA)",
+         "tarifNotesEn" : "Comfort parking on levels Süd -1 and -2",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffNotes" : "Komfortparken auf den Ebenen Süd -1 und -2",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA)"
+      },
+      "tariffPrices" : [ {
+         "id" : 220252,
+         "duration" : "20min"
+      }, {
+         "id" : 220253,
+         "duration" : "30min"
+      }, {
+         "id" : 220254,
+         "duration" : "1hour",
+         "price" : 0.3
+      }, {
+         "id" : 220255,
+         "duration" : "1day",
+         "price" : 10.0
+      }, {
+         "id" : 220256,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220257,
+         "duration" : "1week"
+      }, {
+         "id" : 220258,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220259,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220260,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 220261,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100197,
+      "title" : "Magdeburg Hbf P2 Magdeburg Hbf P2 City Carré ",
+      "station" : {
+         "id" : 3881,
+         "name" : "Magdeburg Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "415",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "City Carré / Hbf - Tiefpreisparken",
+      "nameDisplay" : "Magdeburg Hbf P2 City Carré ",
+      "spaceType" : "Tiefgarage",
+      "spaceTypeEn" : "Underground car park",
+      "spaceTypeName" : "Tiefgarage",
+      "geoLocation" : {
+         "longitude" : 11.628676,
+         "latitude" : 52.129485
+      },
+      "slogan" : "Tiefpreisparken",
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8010224.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Magdeburg",
+         "postalCode" : "39104",
+         "street" : "Kantstraße 3",
+         "supplement" : "Einfahrt: Bahnhofstraße",
+         "supplementEn" : "Access via Bahnhofstraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "904",
+      "numberHandicapedPlaces" : "16",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "250",
+         "clearanceHeight" : "200",
+         "locationNightAccess" : "Nord - neben Kino, Süd - neben SWM",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "ja"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffSpecialEn" : "2nd hour: 0.60, each additional hour: 1.00. 2017: Parking on Saturdays up to 4 hours max. is free of charge! Season parking Night (9:30pm to 7:00am): 33.00 per month.",
+         "tariffSpecial" : "2. Stunde: 0,60, je weitere Stunde: 1,00. 2017: Parkvorgänge bis zu max. 4 Stunden sind an Samstagen kostenlos! Dauerparkvertrag Nachtparken (21:30 bis 7:00 Uhr): 33,00",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA)",
+         "tarifNotesEn" : "Parking levels Süd -3, Nord -1, -2, -3",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffNotes" : "Tiefpreisparken Ebenen Süd -3, Nord -1, -2, -3",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA)"
+      },
+      "tariffPrices" : [ {
+         "id" : 220262,
+         "duration" : "20min"
+      }, {
+         "id" : 220263,
+         "duration" : "30min"
+      }, {
+         "id" : 220264,
+         "duration" : "1hour",
+         "price" : 0.3
+      }, {
+         "id" : 220265,
+         "duration" : "1day",
+         "price" : 4.5
+      }, {
+         "id" : 220266,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220267,
+         "duration" : "1week"
+      }, {
+         "id" : 220268,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220269,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220270,
+         "duration" : "1monthLongTerm",
+         "price" : 75.0
+      }, {
+         "id" : 220271,
+         "duration" : "1monthReservation",
+         "price" : 110.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100198,
+      "title" : "Magdeburg Hbf P3 Parkplatz Magdeburg Hbf Maybachstraße",
+      "station" : {
+         "id" : 3881,
+         "name" : "Magdeburg Hbf"
+      },
+      "label" : "P3",
+      "spaceNumber" : "121",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Maybachstraße",
+      "nameDisplay" : "Parkplatz Magdeburg Hbf Maybachstraße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 11.624166,
+         "latitude" : 52.130202
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8010224.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Magdeburg",
+         "postalCode" : "39104",
+         "street" : "Maybachstraße"
+      },
+      "distance" : "100-149",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "152",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "260",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220242,
+         "duration" : "20min"
+      }, {
+         "id" : 220243,
+         "duration" : "30min",
+         "price" : 0.65
+      }, {
+         "id" : 220244,
+         "duration" : "1hour",
+         "price" : 1.3
+      }, {
+         "id" : 220245,
+         "duration" : "1day",
+         "price" : 5.0
+      }, {
+         "id" : 220246,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220247,
+         "duration" : "1week",
+         "price" : 20.0
+      }, {
+         "id" : 220248,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220249,
+         "duration" : "1monthVendingMachine",
+         "price" : 45.0
+      }, {
+         "id" : 220250,
+         "duration" : "1monthLongTerm",
+         "price" : 45.0
+      }, {
+         "id" : 220251,
+         "duration" : "1monthReservation",
+         "price" : 80.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100199,
+      "title" : "Mainz Hbf P1 Parkplatz Mainz Hbf Alicenstraße",
+      "station" : {
+         "id" : 3898,
+         "name" : "Mainz Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "396",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Mainz Hbf",
+      "nameDisplay" : "Parkplatz Mainz Hbf Alicenstraße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.259793,
+         "latitude" : 50.000769
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000240.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Mainz",
+         "postalCode" : "55116",
+         "street" : "Alicenstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "65",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffNotes" : "Achtung: Veranstaltungsbedingt ist die Alicenbrücke vom 02.10.2017 (6 Uhr) bis zum 03.10.2017 (24 Uhr) komplett gesperrt: Hier leider keine Parkmöglichkeit!",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 948512,
+         "duration" : "20min"
+      }, {
+         "id" : 948513,
+         "duration" : "30min",
+         "price" : 0.8
+      }, {
+         "id" : 948514,
+         "duration" : "1hour",
+         "price" : 1.6
+      }, {
+         "id" : 948515,
+         "duration" : "1day",
+         "price" : 8.0
+      }, {
+         "id" : 948516,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 948517,
+         "duration" : "1week",
+         "price" : 40.0
+      }, {
+         "id" : 948518,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 948519,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 948520,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 948521,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100200,
+      "title" : "Mainz Hbf P2 Parkplatz Mainz Hbf Alicenstraße Brücke",
+      "station" : {
+         "id" : 3898,
+         "name" : "Mainz Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "399",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Mainz Hbf",
+      "nameDisplay" : "Parkplatz Mainz Hbf Alicenstraße Brücke",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.260369,
+         "latitude" : 49.999862
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000240.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Mainz",
+         "postalCode" : "55116",
+         "street" : "Alicenstraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "85",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks from the parking ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffNotes" : "Achtung: Veranstaltungsbedingt ist die Alicenbrücke vom 02.10.2017 (6 Uhr) bis zum 03.10.2017 (24 Uhr) komplett gesperrt: Hier leider keine Parkmöglichkeit!",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 948522,
+         "duration" : "20min"
+      }, {
+         "id" : 948523,
+         "duration" : "30min",
+         "price" : 0.8
+      }, {
+         "id" : 948524,
+         "duration" : "1hour",
+         "price" : 1.6
+      }, {
+         "id" : 948525,
+         "duration" : "1day",
+         "price" : 5.0
+      }, {
+         "id" : 948526,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 948527,
+         "duration" : "1week",
+         "price" : 25.0
+      }, {
+         "id" : 948528,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 948529,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 948530,
+         "duration" : "1monthLongTerm",
+         "price" : 90.0
+      }, {
+         "id" : 948531,
+         "duration" : "1monthReservation",
+         "price" : 120.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100201,
+      "title" : "Mainz Hbf P3 Mainz Hbf P3 Tiefgarage Bonifazius-Türme UG -1",
+      "station" : {
+         "id" : 3898,
+         "name" : "Mainz Hbf"
+      },
+      "label" : "P3",
+      "spaceNumber" : "440",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Tiefgarage Bonifazius-Türme UG -1",
+      "nameDisplay" : "Mainz Hbf P3 Tiefgarage Bonifazius-Türme UG -1",
+      "spaceType" : "Tiefgarage",
+      "spaceTypeEn" : "Underground car park",
+      "spaceTypeName" : "Tiefgarage",
+      "geoLocation" : {
+         "longitude" : 8.26012,
+         "latitude" : 50.00297
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000240.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Mainz",
+         "postalCode" : "55118",
+         "street" : "Bonifaziusstraße"
+      },
+      "distance" : "100-149",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "200",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffSpecialEn" : "Season parking Night (Mon-Fri 3:30pm to 8:30am): 63.00 per month.",
+         "tariffSpecial" : "Dauerparkvertrag Nachtparken (Mo.-Fr. 15:30 bis 8:30 Uhr und an Wochenenden): 63,00 pro Monat",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA), EC-Karte",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA), EC-Card"
+      },
+      "tariffPrices" : [ {
+         "id" : 220292,
+         "duration" : "20min"
+      }, {
+         "id" : 220293,
+         "duration" : "30min"
+      }, {
+         "id" : 220294,
+         "duration" : "1hour",
+         "price" : 2.0
+      }, {
+         "id" : 220295,
+         "duration" : "1day",
+         "price" : 9.0
+      }, {
+         "id" : 220296,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220297,
+         "duration" : "1week"
+      }, {
+         "id" : 220298,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220299,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220300,
+         "duration" : "1monthLongTerm",
+         "price" : 127.0
+      }, {
+         "id" : 220301,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100202,
+      "title" : "Mainz Hbf P4 Mainz Hbf P4 Tiefgarage Bonifazius-Türme UG -2",
+      "station" : {
+         "id" : 3898,
+         "name" : "Mainz Hbf"
+      },
+      "label" : "P4",
+      "spaceNumber" : "441",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Tiefgarage Bonifazius-Türme UG -2",
+      "nameDisplay" : "Mainz Hbf P4 Tiefgarage Bonifazius-Türme UG -2",
+      "spaceType" : "Tiefgarage",
+      "spaceTypeEn" : "Underground car park",
+      "spaceTypeName" : "Tiefgarage",
+      "geoLocation" : {
+         "longitude" : 8.26017,
+         "latitude" : 50.00299
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000240.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Mainz",
+         "postalCode" : "55118",
+         "street" : "Bonifaziusstraße"
+      },
+      "distance" : "100-149",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "219",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffSpecialEn" : "Season parking Night (Mon-Fri 3:30pm to 8:30am): 63.00 per month.",
+         "tariffSpecial" : "Dauerparkvertrag Nachtparken (Mo.-Fr. 15:30 bis 8:30 Uhr und an Wochenenden): 63,00 pro Monat",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA), EC-Karte",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA), EC-Card"
+      },
+      "tariffPrices" : [ {
+         "id" : 220302,
+         "duration" : "20min"
+      }, {
+         "id" : 220303,
+         "duration" : "30min"
+      }, {
+         "id" : 220304,
+         "duration" : "1hour",
+         "price" : 2.0
+      }, {
+         "id" : 220305,
+         "duration" : "1day",
+         "price" : 5.0
+      }, {
+         "id" : 220306,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220307,
+         "duration" : "1week"
+      }, {
+         "id" : 220308,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220309,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220310,
+         "duration" : "1monthLongTerm",
+         "price" : 127.0
+      }, {
+         "id" : 220311,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100204,
+      "title" : "Mainz-Kastel P1 Vorfahrt Bahnhof Mainz-Kastel",
+      "station" : {
+         "id" : 3904,
+         "name" : "Mainz-Kastel"
+      },
+      "label" : "P1",
+      "spaceNumber" : "123",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Vorfahrt Bahnhof Mainz-Kastel",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.282937,
+         "latitude" : 50.007078
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000615.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Wiesbaden",
+         "postalCode" : "55252",
+         "street" : "Eisenbahnstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "27",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "500",
+         "clearanceHeight" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 3 days",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 3 Tage",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220312,
+         "duration" : "20min"
+      }, {
+         "id" : 220313,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 220314,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 220315,
+         "duration" : "1day",
+         "price" : 3.2
+      }, {
+         "id" : 220316,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220317,
+         "duration" : "1week"
+      }, {
+         "id" : 220318,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220319,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220320,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 220321,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100205,
+      "title" : "Mainz-Kastel P2 Bahnhof Mainz-Kastel Rückseite am Gleis",
+      "station" : {
+         "id" : 3904,
+         "name" : "Mainz-Kastel"
+      },
+      "label" : "P2",
+      "spaceNumber" : "304",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Bahnhof Mainz-Kastel Rückseite am Gleis",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.283953,
+         "latitude" : 50.005802
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000615.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Wiesbaden",
+         "postalCode" : "55252",
+         "street" : "Rheinufer 6"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "60",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "500",
+         "clearanceHeight" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffSpecialEn" : "Up to 1.5 hours: 2.00; up to 4 hours: 3.00",
+         "tariffSpecial" : "Bis 1,5 Stunden: 2,00; bis 4 Stunden: 3,00",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Woche oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220322,
+         "duration" : "20min"
+      }, {
+         "id" : 220323,
+         "duration" : "30min"
+      }, {
+         "id" : 220324,
+         "duration" : "1hour"
+      }, {
+         "id" : 220325,
+         "duration" : "1day",
+         "price" : 4.0
+      }, {
+         "id" : 220326,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220327,
+         "duration" : "1week",
+         "price" : 16.0
+      }, {
+         "id" : 220328,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220329,
+         "duration" : "1monthVendingMachine",
+         "price" : 20.0
+      }, {
+         "id" : 220330,
+         "duration" : "1monthLongTerm",
+         "price" : 20.0
+      }, {
+         "id" : 220331,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100206,
+      "title" : "Mainz-Kastel P3 Bahnhof Mainz-Kastel Rückseite",
+      "station" : {
+         "id" : 3904,
+         "name" : "Mainz-Kastel"
+      },
+      "label" : "P3",
+      "spaceNumber" : "314",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Bahnhof Mainz-Kastel Rückseite",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.282604,
+         "latitude" : 50.006352
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000615.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Wiesbaden",
+         "postalCode" : "55252",
+         "street" : "Rheinufer 4-6"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "60",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "500",
+         "clearanceHeight" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffSpecialEn" : "Up to 1.5 hours: 2.00; up to 4 hours: 3.00",
+         "tariffSpecial" : "Bis 1,5 Stunden: 2,00; bis 4 Stunden: 3,00",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Woche oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220332,
+         "duration" : "20min"
+      }, {
+         "id" : 220333,
+         "duration" : "30min"
+      }, {
+         "id" : 220334,
+         "duration" : "1hour"
+      }, {
+         "id" : 220335,
+         "duration" : "1day",
+         "price" : 4.0
+      }, {
+         "id" : 220336,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220337,
+         "duration" : "1week",
+         "price" : 16.0
+      }, {
+         "id" : 220338,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220339,
+         "duration" : "1monthVendingMachine",
+         "price" : 20.0
+      }, {
+         "id" : 220340,
+         "duration" : "1monthLongTerm",
+         "price" : 20.0
+      }, {
+         "id" : 220341,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100207,
+      "title" : "Marktredwitz P1 Vorfahrt Bahnhof Marktredwitz",
+      "station" : {
+         "id" : 3979,
+         "name" : "Marktredwitz"
+      },
+      "label" : "P1",
+      "spaceNumber" : "131",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Vorfahrt Bahnhof Marktredwitz",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 12.082974,
+         "latitude" : 50.004175
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000247.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Marktredwitz",
+         "postalCode" : "95615",
+         "street" : "Bahnhofsplatz"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "15",
+      "numberHandicapedPlaces" : "1",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 1 Woche",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 220342,
+         "duration" : "20min"
+      }, {
+         "id" : 220343,
+         "duration" : "30min",
+         "price" : 0.55
+      }, {
+         "id" : 220344,
+         "duration" : "1hour",
+         "price" : 1.1
+      }, {
+         "id" : 220345,
+         "duration" : "1day",
+         "price" : 4.4
+      }, {
+         "id" : 220346,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220347,
+         "duration" : "1week",
+         "price" : 17.6
+      }, {
+         "id" : 220348,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220349,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220350,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 220351,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100208,
+      "title" : "Marktredwitz P2 Parkplatz Bahnhof Marktredwitz links",
+      "station" : {
+         "id" : 3979,
+         "name" : "Marktredwitz"
+      },
+      "label" : "P2",
+      "spaceNumber" : "129",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Marktredwitz links",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 12.082342,
+         "latitude" : 50.003998
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000247.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Marktredwitz",
+         "postalCode" : "95615",
+         "street" : "Bahnhofsplatz 7"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "25",
+      "numberHandicapedPlaces" : "2",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "400",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 220352,
+         "duration" : "20min"
+      }, {
+         "id" : 220353,
+         "duration" : "30min",
+         "price" : 0.55
+      }, {
+         "id" : 220354,
+         "duration" : "1hour",
+         "price" : 1.1
+      }, {
+         "id" : 220355,
+         "duration" : "1day",
+         "price" : 4.4
+      }, {
+         "id" : 220356,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220357,
+         "duration" : "1week",
+         "price" : 17.6
+      }, {
+         "id" : 220358,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220359,
+         "duration" : "1monthVendingMachine",
+         "price" : 36.0
+      }, {
+         "id" : 220360,
+         "duration" : "1monthLongTerm",
+         "price" : 36.0
+      }, {
+         "id" : 220361,
+         "duration" : "1monthReservation",
+         "price" : 50.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100209,
+      "title" : "Marktredwitz P3 Parkplatz Bahnhof Marktredwitz rechts",
+      "station" : {
+         "id" : 3979,
+         "name" : "Marktredwitz"
+      },
+      "label" : "P3",
+      "spaceNumber" : "130",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Marktredwitz rechts",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 12.084939,
+         "latitude" : 50.005032
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000247.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Marktredwitz",
+         "postalCode" : "95615",
+         "street" : "Kraußoldstraße"
+      },
+      "distance" : "150-199",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "40",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 220362,
+         "duration" : "20min"
+      }, {
+         "id" : 220363,
+         "duration" : "30min",
+         "price" : 0.5
+      }, {
+         "id" : 220364,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 220365,
+         "duration" : "1day",
+         "price" : 2.5
+      }, {
+         "id" : 220366,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220367,
+         "duration" : "1week",
+         "price" : 10.0
+      }, {
+         "id" : 220368,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220369,
+         "duration" : "1monthVendingMachine",
+         "price" : 25.0
+      }, {
+         "id" : 220370,
+         "duration" : "1monthLongTerm",
+         "price" : 25.0
+      }, {
+         "id" : 220371,
+         "duration" : "1monthReservation",
+         "price" : 35.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100216,
+      "title" : "Meißen P1 Vorfahrt Bahnhof Meißen",
+      "station" : {
+         "id" : 4036,
+         "name" : "Meißen"
+      },
+      "label" : "P1",
+      "spaceNumber" : "301",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Vorfahrt Bahnhof Meißen",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 13.482558,
+         "latitude" : 51.163503
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8012326.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Meißen",
+         "postalCode" : "01662",
+         "street" : "Großenhainer Straße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "5",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 day",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 1 Tag",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 220372,
+         "duration" : "20min"
+      }, {
+         "id" : 220373,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 220374,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 220375,
+         "duration" : "1day",
+         "price" : 6.0
+      }, {
+         "id" : 220376,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220377,
+         "duration" : "1week"
+      }, {
+         "id" : 220378,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220379,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220380,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 220381,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100217,
+      "title" : "Memmingen P1 Parkplatz Bahnhof Memmingen",
+      "station" : {
+         "id" : 4051,
+         "name" : "Memmingen"
+      },
+      "label" : "P1",
+      "spaceNumber" : "132",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Memmingen",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 10.186595,
+         "latitude" : 47.98628
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000249.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Memmingen",
+         "postalCode" : "87700",
+         "street" : "Bahnhofstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "16",
+      "numberHandicapedPlaces" : "1",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 3 days",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 3 Tage",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220382,
+         "duration" : "20min"
+      }, {
+         "id" : 220383,
+         "duration" : "30min",
+         "price" : 0.7
+      }, {
+         "id" : 220384,
+         "duration" : "1hour",
+         "price" : 1.4
+      }, {
+         "id" : 220385,
+         "duration" : "1day",
+         "price" : 6.0
+      }, {
+         "id" : 220386,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220387,
+         "duration" : "1week"
+      }, {
+         "id" : 220388,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220389,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220390,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 220391,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100218,
+      "title" : "Minden (Westf) P1 Vorfahrt Bahnhof Minden",
+      "station" : {
+         "id" : 4120,
+         "name" : "Minden (Westf)"
+      },
+      "label" : "P1",
+      "spaceNumber" : "133",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Vorfahrt Bahnhof Minden",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.933625,
+         "latitude" : 52.288981
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000252.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Minden",
+         "postalCode" : "32423",
+         "street" : "Viktoriastraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "20",
+      "numberHandicapedPlaces" : "1",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 3 days",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 3 Tage",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220392,
+         "duration" : "20min"
+      }, {
+         "id" : 220393,
+         "duration" : "30min",
+         "price" : 0.7
+      }, {
+         "id" : 220394,
+         "duration" : "1hour",
+         "price" : 1.4
+      }, {
+         "id" : 220395,
+         "duration" : "1day",
+         "price" : 6.0
+      }, {
+         "id" : 220396,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220397,
+         "duration" : "1week"
+      }, {
+         "id" : 220398,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220399,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220400,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 220401,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100219,
+      "title" : "Minden (Westf) P2 Parkplatz Bahnhof Minden Schwarzer Weg ",
+      "station" : {
+         "id" : 4120,
+         "name" : "Minden (Westf)"
+      },
+      "label" : "P2",
+      "spaceNumber" : "134",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Minden Schwarzer Weg ",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.932415,
+         "latitude" : 52.289133
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000252.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Minden",
+         "postalCode" : "32423",
+         "street" : "Kaiserstraße/Schwarzer Weg"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "80",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 11 days or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 11 Tage oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220402,
+         "duration" : "20min"
+      }, {
+         "id" : 220403,
+         "duration" : "30min",
+         "price" : 0.5
+      }, {
+         "id" : 220404,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 220405,
+         "duration" : "1day",
+         "price" : 3.5
+      }, {
+         "id" : 220406,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220407,
+         "duration" : "1week",
+         "price" : 17.5
+      }, {
+         "id" : 220408,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220409,
+         "duration" : "1monthVendingMachine",
+         "price" : 32.0
+      }, {
+         "id" : 220410,
+         "duration" : "1monthLongTerm",
+         "price" : 32.0
+      }, {
+         "id" : 220411,
+         "duration" : "1monthReservation",
+         "price" : 45.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100220,
+      "title" : "Minden (Westf) P3 Parkplatz Bahnhof Minden am Gleis",
+      "station" : {
+         "id" : 4120,
+         "name" : "Minden (Westf)"
+      },
+      "label" : "P3",
+      "spaceNumber" : "377",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Minden am Gleis",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.936169,
+         "latitude" : 52.290723
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000252.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Minden",
+         "postalCode" : "32423",
+         "street" : "Bahnstraße"
+      },
+      "distance" : "100-149",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "122",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 8 days or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 8 Tage oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 836729,
+         "duration" : "20min"
+      }, {
+         "id" : 836730,
+         "duration" : "30min",
+         "price" : 0.7
+      }, {
+         "id" : 836731,
+         "duration" : "1hour",
+         "price" : 1.4
+      }, {
+         "id" : 836732,
+         "duration" : "1day",
+         "price" : 5.6
+      }, {
+         "id" : 836733,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 836734,
+         "duration" : "1week",
+         "price" : 22.4
+      }, {
+         "id" : 836735,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 836736,
+         "duration" : "1monthVendingMachine",
+         "price" : 30.0
+      }, {
+         "id" : 836737,
+         "duration" : "1monthLongTerm",
+         "price" : 30.0
+      }, {
+         "id" : 836738,
+         "duration" : "1monthReservation",
+         "price" : 45.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100221,
+      "title" : "Minden (Westf) P4 Bahnhof Minden Schwarzer Weg Süd",
+      "station" : {
+         "id" : 4120,
+         "name" : "Minden (Westf)"
+      },
+      "label" : "P4",
+      "spaceNumber" : "135",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Bahnhof Minden Schwarzer Weg Süd",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.932712,
+         "latitude" : 52.288661
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000252.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Minden",
+         "postalCode" : "32423",
+         "street" : "Schwarzer Weg"
+      },
+      "distance" : "100-149",
+      "facilityType" : "keine",
+      "facilityTypeEn" : "none",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "15",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffFreeParkingTimeEn" : "nein"
+      },
+      "tariffPrices" : [ {
+         "id" : 220422,
+         "duration" : "20min"
+      }, {
+         "id" : 220423,
+         "duration" : "30min"
+      }, {
+         "id" : 220424,
+         "duration" : "1hour"
+      }, {
+         "id" : 220425,
+         "duration" : "1day"
+      }, {
+         "id" : 220426,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220427,
+         "duration" : "1week"
+      }, {
+         "id" : 220428,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220429,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220430,
+         "duration" : "1monthLongTerm",
+         "price" : 20.0
+      }, {
+         "id" : 220431,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100210,
+      "title" : "München Hbf P1 München Hbf P1 Vorplatz Bayerstraße",
+      "station" : {
+         "id" : 4234,
+         "name" : "München Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "139",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Bayerstraße",
+      "nameDisplay" : "München Hbf P1 Vorplatz Bayerstraße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 11.558023,
+         "latitude" : 48.139413
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000261.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "München",
+         "postalCode" : "80335",
+         "street" : "Bayerstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "40",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "500",
+         "clearanceHeight" : "600",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 3 days",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 3 Tage",
+         "tarifNotesEn" : "In lay-bys along Bayerstraße max. 3 hours parking.",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffNotes" : "Max. 3 Stunden Parkdauer in den Parkbuchten entlang der Bayerstraße.",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 877688,
+         "duration" : "20min"
+      }, {
+         "id" : 877689,
+         "duration" : "30min"
+      }, {
+         "id" : 877690,
+         "duration" : "1hour",
+         "price" : 3.0
+      }, {
+         "id" : 877691,
+         "duration" : "1day",
+         "price" : 30.0
+      }, {
+         "id" : 877692,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 877693,
+         "duration" : "1week"
+      }, {
+         "id" : 877694,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 877695,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 877696,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 877697,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100211,
+      "title" : "München Hbf P2 Parkhaus München Hbf",
+      "station" : {
+         "id" : 4234,
+         "name" : "München Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "136",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkhaus München Hauptbahnhof",
+      "nameDisplay" : "Parkhaus München Hbf",
+      "spaceType" : "Parkhaus",
+      "spaceTypeEn" : "Multi storey car park",
+      "spaceTypeName" : "Parkhaus",
+      "geoLocation" : {
+         "longitude" : 11.560396,
+         "latitude" : 48.140151
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000261.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "München",
+         "postalCode" : "80335",
+         "street" : "Arnulfstraße 1; Bayerstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "243",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "250",
+         "clearanceHeight" : "200",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : true,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : true,
+         "isDiscountDbParkAndRail" : true,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffDiscount" : "Bonierung im DB Reisezentrum und an der DB Information. Rabattierung mit BahnCard direkt am Kassenautomaten.",
+         "tariffFreeParkingTime" : "nein",
+         "tariffSpecialEn" : "A separate tariff applies for the inner courtyard areas. ",
+         "tariffSpecial" : "Auf den Ladehöfen gilt ein abweichender Tarif.",
+         "tariffDiscountEn" : "Reduction from the DB Information and the DB Reisezentrum (travel centre). BahnCard discount available directly at the pay station.",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA), P Card",
+         "tariffPaymentCustomerCards" : "P Card",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA), P Card"
+      },
+      "tariffPrices" : [ {
+         "id" : 220442,
+         "duration" : "20min"
+      }, {
+         "id" : 220443,
+         "duration" : "30min"
+      }, {
+         "id" : 220444,
+         "duration" : "1hour",
+         "price" : 3.0
+      }, {
+         "id" : 220445,
+         "duration" : "1day",
+         "price" : 25.0
+      }, {
+         "id" : 220446,
+         "duration" : "1dayDiscount",
+         "price" : 20.0
+      }, {
+         "id" : 220447,
+         "duration" : "1week"
+      }, {
+         "id" : 220448,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220449,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220450,
+         "duration" : "1monthLongTerm",
+         "price" : 185.0
+      }, {
+         "id" : 220451,
+         "duration" : "1monthReservation",
+         "price" : 250.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100213,
+      "title" : "München Hbf P4 München Hbf P4 Tiefgarage Hbf Süd",
+      "station" : {
+         "id" : 4234,
+         "name" : "München Hbf"
+      },
+      "label" : "P4",
+      "spaceNumber" : "298",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Tiefgarage München Hauptbahnhof Süd",
+      "nameDisplay" : "München Hbf P4 Tiefgarage Hbf Süd",
+      "spaceType" : "Tiefgarage",
+      "spaceTypeEn" : "Underground car park",
+      "spaceTypeName" : "Tiefgarage",
+      "geoLocation" : {
+         "longitude" : 11.560039,
+         "latitude" : 48.138542
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000261.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "München",
+         "postalCode" : "80336",
+         "street" : "Senefelderstraße/Goethestraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "242",
+      "numberHandicapedPlaces" : "1",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "250",
+         "clearanceHeight" : "200",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : true,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffDiscount" : "Bonierung an der DB Information oder im DB Reisezentrum. Zahlung anschließend am Kassenautomaten.",
+         "tariffFreeParkingTime" : "nein",
+         "tariffDiscountEn" : "Reduction from the DB Information or the DB Reisezentrum (travel centre). Then pay at the pay station.",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA)",
+         "tariffPointOfSale" : "Park&Rail-Karten erhältlich an allen Verkaufsstellen der Deutschen Bahn (außer Internet).",
+         "tariffPointOfSaleEn" : "Park&Rail cards available from all Deutsche Bahn points of sale (except online).  ",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA)"
+      },
+      "tariffPrices" : [ {
+         "id" : 871803,
+         "duration" : "20min"
+      }, {
+         "id" : 871804,
+         "duration" : "30min"
+      }, {
+         "id" : 871805,
+         "duration" : "1hour",
+         "price" : 2.0
+      }, {
+         "id" : 871806,
+         "duration" : "1day",
+         "price" : 30.0
+      }, {
+         "id" : 871807,
+         "duration" : "1dayDiscount",
+         "price" : 9.0
+      }, {
+         "id" : 871808,
+         "duration" : "1week"
+      }, {
+         "id" : 871809,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 871810,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 871811,
+         "duration" : "1monthLongTerm",
+         "price" : 150.0
+      }, {
+         "id" : 871812,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100223,
+      "title" : "Neunkirchen (Saar) Hbf P1 Vorplatz Neunkirchen Hbf",
+      "station" : {
+         "id" : 4426,
+         "name" : "Neunkirchen (Saar) Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "144",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Vorplatz Neunkirchen Hbf",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 7.177799,
+         "latitude" : 49.353431
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000272.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Neunkirchen an der Saar",
+         "postalCode" : "66538",
+         "street" : "Am Bahnhof"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "84",
+      "numberHandicapedPlaces" : "1",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "400",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffNotesEn" : "",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffNotes" : "",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 609280,
+         "duration" : "20min"
+      }, {
+         "id" : 609281,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 609282,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 609283,
+         "duration" : "1day",
+         "price" : 2.0
+      }, {
+         "id" : 609284,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 609285,
+         "duration" : "1week",
+         "price" : 10.0
+      }, {
+         "id" : 609286,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 609287,
+         "duration" : "1monthVendingMachine",
+         "price" : 25.0
+      }, {
+         "id" : 609288,
+         "duration" : "1monthLongTerm",
+         "price" : 25.0
+      }, {
+         "id" : 609289,
+         "duration" : "1monthReservation",
+         "price" : 30.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100224,
+      "title" : "Neunkirchen (Saar) Hbf P2 Parkplatz Neunkirchen Hbf an den Gleisen",
+      "station" : {
+         "id" : 4426,
+         "name" : "Neunkirchen (Saar) Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "143",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Neunkirchen Hbf an den Gleisen",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 7.177385,
+         "latitude" : 49.353667
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000272.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Neunkirchen an der Saar",
+         "postalCode" : "66538",
+         "street" : "Am Bahnhof"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "28",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "370",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffNotesEn" : "",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffNotes" : "",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 609290,
+         "duration" : "20min"
+      }, {
+         "id" : 609291,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 609292,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 609293,
+         "duration" : "1day",
+         "price" : 2.0
+      }, {
+         "id" : 609294,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 609295,
+         "duration" : "1week",
+         "price" : 10.0
+      }, {
+         "id" : 609296,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 609297,
+         "duration" : "1monthVendingMachine",
+         "price" : 25.0
+      }, {
+         "id" : 609298,
+         "duration" : "1monthLongTerm",
+         "price" : 25.0
+      }, {
+         "id" : 609299,
+         "duration" : "1monthReservation",
+         "price" : 30.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100225,
+      "title" : "Neuss Hbf P1 Vorplatz Neuss Hbf",
+      "station" : {
+         "id" : 4440,
+         "name" : "Neuss Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "145",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Vorplatz Neuss Hbf",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 6.683308,
+         "latitude" : 51.203641
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000274.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Neuss",
+         "postalCode" : "41460",
+         "street" : "Zufuhrstraße/Further Straße 1"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "20",
+      "numberHandicapedPlaces" : "1",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 1 Woche",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 220482,
+         "duration" : "20min"
+      }, {
+         "id" : 220483,
+         "duration" : "30min",
+         "price" : 0.7
+      }, {
+         "id" : 220484,
+         "duration" : "1hour",
+         "price" : 1.4
+      }, {
+         "id" : 220485,
+         "duration" : "1day",
+         "price" : 3.8
+      }, {
+         "id" : 220486,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220487,
+         "duration" : "1week",
+         "price" : 19.0
+      }, {
+         "id" : 220488,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220489,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220490,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 220491,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100226,
+      "title" : "Neustadt (Weinstr) Hbf P1 Parkplatz Neustadt (Weinstr) Hbf links",
+      "station" : {
+         "id" : 4454,
+         "name" : "Neustadt (Weinstr) Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "147",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Neustadt (Weinstr) Hbf links",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.14026,
+         "latitude" : 49.350147
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000275.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Neustadt an der Weinstraße",
+         "postalCode" : "67434",
+         "street" : "Postamtplatz"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "numberParkingPlaces" : "22",
+      "numberHandicapedPlaces" : "2",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : true,
+      "outOfServiceText" : "Deutsches Weinlesefest: Parkplatz bis 11.10.2017 gesperrt.",
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+      },
+      "tariffInfo" : {
+      },
+      "tariffPrices" : [ ]
+   }, {
+      "type" : "space",
+      "id" : 100227,
+      "title" : "Neustadt (Weinstr) Hbf P2 Vorplatz Neustadt (Weinstr) Hbf",
+      "station" : {
+         "id" : 4454,
+         "name" : "Neustadt (Weinstr) Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "148",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Vorplatz Neustadt (Weinstr) Hbf",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.140764,
+         "latitude" : 49.350115
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000275.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Neustadt an der Weinstraße",
+         "postalCode" : "67434",
+         "street" : "Bahnhofsplatz"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "numberParkingPlaces" : "36",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : true,
+      "outOfServiceText" : "Deutsches Weinlesefest: Parkplatz bis 11.10.2017 gesperrt.",
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+      },
+      "tariffInfo" : {
+      },
+      "tariffPrices" : [ ]
+   }, {
+      "type" : "space",
+      "id" : 100228,
+      "title" : "Neustadt (Weinstr) Hbf P3 Parkplatz Neustadt (Weinstr) Hbf rechts",
+      "station" : {
+         "id" : 4454,
+         "name" : "Neustadt (Weinstr) Hbf"
+      },
+      "label" : "P3",
+      "spaceNumber" : "146",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Neustadt (Weinstr) Hbf rechts",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.141814,
+         "latitude" : 49.349919
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000275.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Neustadt an der Weinstraße",
+         "postalCode" : "67434",
+         "street" : "Bahnhofsplatz"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "84",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks from the parking ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffSpecialEn" : "Deutsches Weinlesefest, 2pm till 3am: 1 hour 1.50, 1 day 8.00",
+         "tariffSpecial" : "Deutsches Weinlesefest, 14:00 bis 03:00 Uhr: 1 Stunde 1,50, 1 Tag 8,00",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 918936,
+         "duration" : "20min"
+      }, {
+         "id" : 918937,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 918938,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 918939,
+         "duration" : "1day",
+         "price" : 3.2
+      }, {
+         "id" : 918940,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 918941,
+         "duration" : "1week",
+         "price" : 12.8
+      }, {
+         "id" : 918942,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 918943,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 918944,
+         "duration" : "1monthLongTerm",
+         "price" : 38.0
+      }, {
+         "id" : 918945,
+         "duration" : "1monthReservation",
+         "price" : 70.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100229,
+      "title" : "Neustadt (Weinstr) Hbf P4 Parkplatz Neustadt Hbf Landauer Straße",
+      "station" : {
+         "id" : 4454,
+         "name" : "Neustadt (Weinstr) Hbf"
+      },
+      "label" : "P4",
+      "spaceNumber" : "353",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Neustadt Hbf Landauer Straße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.143048,
+         "latitude" : 49.350209
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000275.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Neustadt an der Weinstraße",
+         "postalCode" : "67433",
+         "street" : "Landauer Straße 43"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "67",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "450",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffSpecialEn" : "Deutsches Weinlesefest, 2pm till 3am: 1 hour 1.50, 1 day 8.00",
+         "tariffSpecial" : "Deutsches Weinlesefest, 14:00 bis 03:00 Uhr: 1 Stunde 1,50, 1 Tag 8,00",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 918946,
+         "duration" : "20min"
+      }, {
+         "id" : 918947,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 918948,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 918949,
+         "duration" : "1day",
+         "price" : 3.0
+      }, {
+         "id" : 918950,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 918951,
+         "duration" : "1week",
+         "price" : 12.0
+      }, {
+         "id" : 918952,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 918953,
+         "duration" : "1monthVendingMachine",
+         "price" : 30.0
+      }, {
+         "id" : 918954,
+         "duration" : "1monthLongTerm",
+         "price" : 30.0
+      }, {
+         "id" : 918955,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100230,
+      "title" : "Niebüll P1 Parkplatz Bahnhof Niebüll Lagedeich",
+      "station" : {
+         "id" : 4472,
+         "name" : "Niebüll"
+      },
+      "label" : "P1",
+      "spaceNumber" : "416",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Lagedeich",
+      "nameDisplay" : "Parkplatz Bahnhof Niebüll Lagedeich",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.835114,
+         "latitude" : 54.790835
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8004343.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Niebüll",
+         "postalCode" : "25899",
+         "street" : "Lagedeich"
+      },
+      "distance" : "100",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "40",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 11 days or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 11 Tage oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220532,
+         "duration" : "20min"
+      }, {
+         "id" : 220533,
+         "duration" : "30min"
+      }, {
+         "id" : 220534,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 220535,
+         "duration" : "1day",
+         "price" : 3.0
+      }, {
+         "id" : 220536,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220537,
+         "duration" : "1week",
+         "price" : 15.0
+      }, {
+         "id" : 220538,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220539,
+         "duration" : "1monthVendingMachine",
+         "price" : 30.0
+      }, {
+         "id" : 220540,
+         "duration" : "1monthLongTerm",
+         "price" : 30.0
+      }, {
+         "id" : 220541,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100231,
+      "title" : "Nordhausen P1 Parkplatz Bahnhof Nordhausen",
+      "station" : {
+         "id" : 4576,
+         "name" : "Nordhausen"
+      },
+      "label" : "P1",
+      "spaceNumber" : "149",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Nordhausen",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 10.790216,
+         "latitude" : 51.492974
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8010256.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Nordhausen",
+         "postalCode" : "99734",
+         "street" : "Lange Straße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "31",
+      "numberHandicapedPlaces" : "2",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 220542,
+         "duration" : "20min"
+      }, {
+         "id" : 220543,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 220544,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 220545,
+         "duration" : "1day",
+         "price" : 3.8
+      }, {
+         "id" : 220546,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220547,
+         "duration" : "1week",
+         "price" : 15.2
+      }, {
+         "id" : 220548,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220549,
+         "duration" : "1monthVendingMachine",
+         "price" : 32.0
+      }, {
+         "id" : 220550,
+         "duration" : "1monthLongTerm",
+         "price" : 32.0
+      }, {
+         "id" : 220551,
+         "duration" : "1monthReservation",
+         "price" : 50.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100232,
+      "title" : "Offenburg P1 Parkplatz Bahnhof Offenburg Rheinstraße",
+      "station" : {
+         "id" : 4745,
+         "name" : "Offenburg"
+      },
+      "label" : "P1",
+      "spaceNumber" : "151",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Offenburg Rheinstraße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 7.946301,
+         "latitude" : 48.478493
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000290.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Offenburg",
+         "postalCode" : "77652",
+         "street" : "Hauptstraße / Rheinstraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "100",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks from the parking ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220552,
+         "duration" : "20min"
+      }, {
+         "id" : 220553,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 220554,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 220555,
+         "duration" : "1day",
+         "price" : 4.0
+      }, {
+         "id" : 220556,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220557,
+         "duration" : "1week",
+         "price" : 16.0
+      }, {
+         "id" : 220558,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220559,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220560,
+         "duration" : "1monthLongTerm",
+         "price" : 60.0
+      }, {
+         "id" : 220561,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100233,
+      "title" : "Offenburg P2 Parkplatz Offenburg Rammersweierstraße",
+      "station" : {
+         "id" : 4745,
+         "name" : "Offenburg"
+      },
+      "label" : "P2",
+      "spaceNumber" : "150",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Offenburg Rammersweierstraße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 7.949068,
+         "latitude" : 48.478112
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000290.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Offenburg",
+         "postalCode" : "77652",
+         "street" : "Rammersweierstraße"
+      },
+      "distance" : "200-250",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "56",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks from the parking ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220562,
+         "duration" : "20min"
+      }, {
+         "id" : 220563,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 220564,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 220565,
+         "duration" : "1day",
+         "price" : 4.0
+      }, {
+         "id" : 220566,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220567,
+         "duration" : "1week",
+         "price" : 16.0
+      }, {
+         "id" : 220568,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220569,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220570,
+         "duration" : "1monthLongTerm",
+         "price" : 60.0
+      }, {
+         "id" : 220571,
+         "duration" : "1monthReservation",
+         "price" : 100.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100234,
+      "title" : "Osnabrück Hbf P1 Parkplatz Osnabrück Hbf Humboldtbrücke",
+      "station" : {
+         "id" : 4787,
+         "name" : "Osnabrück Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "152",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz an der Humboldtbrücke",
+      "nameDisplay" : "Parkplatz Osnabrück Hbf Humboldtbrücke",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.059765,
+         "latitude" : 52.274256
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000294.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Osnabrück",
+         "postalCode" : "49074",
+         "street" : "An der Humboldtbrücke 8"
+      },
+      "distance" : "200-250",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "70",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 11 days or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 11 Tage oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220572,
+         "duration" : "20min"
+      }, {
+         "id" : 220573,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 220574,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 220575,
+         "duration" : "1day",
+         "price" : 4.5
+      }, {
+         "id" : 220576,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220577,
+         "duration" : "1week",
+         "price" : 22.5
+      }, {
+         "id" : 220578,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220579,
+         "duration" : "1monthVendingMachine",
+         "price" : 43.0
+      }, {
+         "id" : 220580,
+         "duration" : "1monthLongTerm",
+         "price" : 43.0
+      }, {
+         "id" : 220581,
+         "duration" : "1monthReservation",
+         "price" : 60.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100235,
+      "title" : "Osnabrück Hbf P2 Parkplatz Osnabrück Hbf Eisenbahnstraße",
+      "station" : {
+         "id" : 4787,
+         "name" : "Osnabrück Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "438",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Eisenbahnstraße",
+      "nameDisplay" : "Parkplatz Osnabrück Hbf Eisenbahnstraße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.057658,
+         "latitude" : 52.274056
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000294.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Osnabrück",
+         "postalCode" : "49074",
+         "street" : "Eisenbahnstraße"
+      },
+      "distance" : "100-149",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "35",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220582,
+         "duration" : "20min"
+      }, {
+         "id" : 220583,
+         "duration" : "30min"
+      }, {
+         "id" : 220584,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 220585,
+         "duration" : "1day",
+         "price" : 5.0
+      }, {
+         "id" : 220586,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220587,
+         "duration" : "1week",
+         "price" : 25.0
+      }, {
+         "id" : 220588,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220589,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220590,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 220591,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100237,
+      "title" : "Passau Hbf P1 Vorfahrt Passau Hbf",
+      "station" : {
+         "id" : 4872,
+         "name" : "Passau Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "157",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Vorfahrt Passau Hbf",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 13.451078,
+         "latitude" : 48.57418
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000298.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Passau",
+         "postalCode" : "94032",
+         "street" : "Bahnhofstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "7",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 4 hours",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 4 Stunden",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220592,
+         "duration" : "20min"
+      }, {
+         "id" : 220593,
+         "duration" : "30min",
+         "price" : 0.8
+      }, {
+         "id" : 220594,
+         "duration" : "1hour",
+         "price" : 1.6
+      }, {
+         "id" : 220595,
+         "duration" : "1day"
+      }, {
+         "id" : 220596,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220597,
+         "duration" : "1week"
+      }, {
+         "id" : 220598,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220599,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220600,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 220601,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100238,
+      "title" : "Passau Hbf P2 Parkplatz Passau Hbf",
+      "station" : {
+         "id" : 4872,
+         "name" : "Passau Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "154",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Passau Hbf",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 13.447566,
+         "latitude" : 48.574245
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000298.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Passau",
+         "postalCode" : "94032",
+         "street" : "Bahnhofstraße 29"
+      },
+      "distance" : "200-250",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "52",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : true,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks from the parking ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffPointOfSale" : "Park&Rail-Karten erhältlich an allen Verkaufsstellen der Deutschen Bahn (außer Internet).",
+         "tariffPointOfSaleEn" : "Park&Rail cards available from all Deutsche Bahn points of sale (except online).  ",
+         "tariffMaxParkingTime" : "Max. 2 Wochen am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220602,
+         "duration" : "20min"
+      }, {
+         "id" : 220603,
+         "duration" : "30min"
+      }, {
+         "id" : 220604,
+         "duration" : "1hour",
+         "price" : 1.4
+      }, {
+         "id" : 220605,
+         "duration" : "1day",
+         "price" : 5.0
+      }, {
+         "id" : 220606,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220607,
+         "duration" : "1week",
+         "price" : 25.0
+      }, {
+         "id" : 220608,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220609,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220610,
+         "duration" : "1monthLongTerm",
+         "price" : 60.0
+      }, {
+         "id" : 220611,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100239,
+      "title" : "Passau Hbf P3 Parkplatz Passau Hbf West",
+      "station" : {
+         "id" : 4872,
+         "name" : "Passau Hbf"
+      },
+      "label" : "P3",
+      "spaceNumber" : "286",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Passau Hbf West",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 13.446778,
+         "latitude" : 48.574166
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000298.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Passau",
+         "postalCode" : "94032",
+         "street" : "Bahnhofstraße"
+      },
+      "distance" : "200-250",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "35",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks from the parking ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220612,
+         "duration" : "20min"
+      }, {
+         "id" : 220613,
+         "duration" : "30min"
+      }, {
+         "id" : 220614,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 220615,
+         "duration" : "1day",
+         "price" : 4.5
+      }, {
+         "id" : 220616,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220617,
+         "duration" : "1week",
+         "price" : 25.0
+      }, {
+         "id" : 220618,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220619,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220620,
+         "duration" : "1monthLongTerm",
+         "price" : 60.0
+      }, {
+         "id" : 220621,
+         "duration" : "1monthReservation",
+         "price" : 80.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100240,
+      "title" : "Passau Hbf P4 Passau Hbf P4 Parkhaus Donaupassage",
+      "station" : {
+         "id" : 4872,
+         "name" : "Passau Hbf"
+      },
+      "label" : "P4",
+      "spaceNumber" : "378",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkhaus Donaupassage",
+      "nameDisplay" : "Passau Hbf P4 Parkhaus Donaupassage",
+      "spaceType" : "Parkhaus",
+      "spaceTypeEn" : "Multi storey car park",
+      "spaceTypeName" : "Parkhaus",
+      "geoLocation" : {
+         "longitude" : 13.45101,
+         "latitude" : 48.57492
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000298.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Passau",
+         "postalCode" : "94032",
+         "street" : "Obere Donaulände"
+      },
+      "distance" : "150-199",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "559",
+      "numberHandicapedPlaces" : "4",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "clearanceHeight" : "210",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "30 Min.",
+         "tariffSpecialEn" : "The daily tariff applies per parking session per calendar day until 2.00am. ",
+         "tariffSpecial" : "Der Tagestarif gilt je Parkvorgang pro Kalendertag bis 02:00 Uhr früh.",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA)",
+         "tariffFreeParkingTimeEn" : "30 mins.",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA)"
+      },
+      "tariffPrices" : [ {
+         "id" : 220622,
+         "duration" : "20min"
+      }, {
+         "id" : 220623,
+         "duration" : "30min"
+      }, {
+         "id" : 220624,
+         "duration" : "1hour",
+         "price" : 1.4
+      }, {
+         "id" : 220625,
+         "duration" : "1day",
+         "price" : 4.0
+      }, {
+         "id" : 220626,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220627,
+         "duration" : "1week"
+      }, {
+         "id" : 220628,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220629,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220630,
+         "duration" : "1monthLongTerm",
+         "price" : 60.0
+      }, {
+         "id" : 220631,
+         "duration" : "1monthReservation",
+         "price" : 120.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100241,
+      "title" : "Plattling P1 Parkplatz Bahnhof Plattling Lagerhausstr",
+      "station" : {
+         "id" : 4952,
+         "name" : "Plattling"
+      },
+      "label" : "P1",
+      "spaceNumber" : "159",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Plattling Lagerhausstr",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 12.862637,
+         "latitude" : 48.778701
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000301.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Plattling",
+         "postalCode" : "94447",
+         "street" : "Lagerhausstraße"
+      },
+      "distance" : "100-149",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "120",
+      "numberHandicapedPlaces" : "2",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 220632,
+         "duration" : "20min"
+      }, {
+         "id" : 220633,
+         "duration" : "30min",
+         "price" : 0.5
+      }, {
+         "id" : 220634,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 220635,
+         "duration" : "1day",
+         "price" : 3.0
+      }, {
+         "id" : 220636,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220637,
+         "duration" : "1week",
+         "price" : 9.0
+      }, {
+         "id" : 220638,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220639,
+         "duration" : "1monthVendingMachine",
+         "price" : 35.0
+      }, {
+         "id" : 220640,
+         "duration" : "1monthLongTerm",
+         "price" : 35.0
+      }, {
+         "id" : 220641,
+         "duration" : "1monthReservation",
+         "price" : 45.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100242,
+      "title" : "Plochingen P1 Parkhaus Bahnhof Plochingen",
+      "station" : {
+         "id" : 4967,
+         "name" : "Plochingen"
+      },
+      "label" : "P1",
+      "spaceNumber" : "414",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkhaus Bahnhof Plochingen",
+      "nameDisplay" : "Parkhaus Bahnhof Plochingen",
+      "spaceType" : "Parkhaus",
+      "spaceTypeEn" : "Multi storey car park",
+      "spaceTypeName" : "Parkhaus",
+      "geoLocation" : {
+         "longitude" : 9.411712,
+         "latitude" : 48.713849
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000302.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Plochingen",
+         "postalCode" : "73207",
+         "street" : "Eisenbahnstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "268",
+      "numberHandicapedPlaces" : "3",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week from the parking ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffSpecialEn" : "4 hours: 2.50. 6 month ticket for EUR 135.00 available from the VVS. ",
+         "tariffSpecial" : "4 Stunden: 2,50. Halbjahreskarten zum Preis von EUR 135,00 über den VVS erhältlich.",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Woche am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220642,
+         "duration" : "20min"
+      }, {
+         "id" : 220643,
+         "duration" : "30min"
+      }, {
+         "id" : 220644,
+         "duration" : "1hour"
+      }, {
+         "id" : 220645,
+         "duration" : "1day",
+         "price" : 4.0
+      }, {
+         "id" : 220646,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220647,
+         "duration" : "1week",
+         "price" : 15.0
+      }, {
+         "id" : 220648,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220649,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220650,
+         "duration" : "1monthLongTerm",
+         "price" : 50.0
+      }, {
+         "id" : 220651,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100243,
+      "title" : "Prien am Chiemsee P1 Parkplatz Bahnhof Prien links",
+      "station" : {
+         "id" : 5035,
+         "name" : "Prien am Chiemsee"
+      },
+      "label" : "P1",
+      "spaceNumber" : "160",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Prien links",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 12.34638,
+         "latitude" : 47.855681
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8004885.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Prien am Chiemsee",
+         "postalCode" : "83209",
+         "street" : "Bahnhofstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "33",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 220652,
+         "duration" : "20min"
+      }, {
+         "id" : 220653,
+         "duration" : "30min"
+      }, {
+         "id" : 220654,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 220655,
+         "duration" : "1day",
+         "price" : 4.2
+      }, {
+         "id" : 220656,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220657,
+         "duration" : "1week",
+         "price" : 16.8
+      }, {
+         "id" : 220658,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220659,
+         "duration" : "1monthVendingMachine",
+         "price" : 50.0
+      }, {
+         "id" : 220660,
+         "duration" : "1monthLongTerm",
+         "price" : 50.0
+      }, {
+         "id" : 220661,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100244,
+      "title" : "Rastatt P1 Parkplatz Bahnhof Rastatt Rückseite",
+      "station" : {
+         "id" : 5125,
+         "name" : "Rastatt"
+      },
+      "label" : "P1",
+      "spaceNumber" : "162",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Rastatt Rückseite",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.216392,
+         "latitude" : 48.86056
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000306.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Rastatt",
+         "postalCode" : "76437",
+         "street" : "Rauentaler Straße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "54",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220662,
+         "duration" : "20min"
+      }, {
+         "id" : 220663,
+         "duration" : "30min"
+      }, {
+         "id" : 220664,
+         "duration" : "1hour",
+         "price" : 0.5
+      }, {
+         "id" : 220665,
+         "duration" : "1day",
+         "price" : 1.5
+      }, {
+         "id" : 220666,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220667,
+         "duration" : "1week",
+         "price" : 6.0
+      }, {
+         "id" : 220668,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220669,
+         "duration" : "1monthVendingMachine",
+         "price" : 22.0
+      }, {
+         "id" : 220670,
+         "duration" : "1monthLongTerm",
+         "price" : 22.0
+      }, {
+         "id" : 220671,
+         "duration" : "1monthReservation",
+         "price" : 25.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100245,
+      "title" : "Rastatt P2 Parkplatz Bahnhof Rastatt Rastatt links",
+      "station" : {
+         "id" : 5125,
+         "name" : "Rastatt"
+      },
+      "label" : "P2",
+      "spaceNumber" : "163",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Rastatt Rastatt links",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.215763,
+         "latitude" : 48.861259
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000306.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Rastatt",
+         "postalCode" : "76437",
+         "street" : "Niederwaldstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "21",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220672,
+         "duration" : "20min"
+      }, {
+         "id" : 220673,
+         "duration" : "30min",
+         "price" : 0.55
+      }, {
+         "id" : 220674,
+         "duration" : "1hour",
+         "price" : 1.1
+      }, {
+         "id" : 220675,
+         "duration" : "1day",
+         "price" : 2.75
+      }, {
+         "id" : 220676,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220677,
+         "duration" : "1week",
+         "price" : 11.0
+      }, {
+         "id" : 220678,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220679,
+         "duration" : "1monthVendingMachine",
+         "price" : 25.0
+      }, {
+         "id" : 220680,
+         "duration" : "1monthLongTerm",
+         "price" : 25.0
+      }, {
+         "id" : 220681,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100246,
+      "title" : "Rastatt P3 Parkplatz Bahnhof Rastatt Rastatt rechts",
+      "station" : {
+         "id" : 5125,
+         "name" : "Rastatt"
+      },
+      "label" : "P3",
+      "spaceNumber" : "161",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Rastatt Rastatt rechts",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.214545,
+         "latitude" : 48.859677
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000306.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Rastatt",
+         "postalCode" : "76437",
+         "street" : "Steinmetzstraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "16",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 10 days or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 10 Tage oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220682,
+         "duration" : "20min"
+      }, {
+         "id" : 220683,
+         "duration" : "30min",
+         "price" : 0.55
+      }, {
+         "id" : 220684,
+         "duration" : "1hour",
+         "price" : 1.1
+      }, {
+         "id" : 220685,
+         "duration" : "1day",
+         "price" : 2.75
+      }, {
+         "id" : 220686,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220687,
+         "duration" : "1week",
+         "price" : 11.0
+      }, {
+         "id" : 220688,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220689,
+         "duration" : "1monthVendingMachine",
+         "price" : 22.0
+      }, {
+         "id" : 220690,
+         "duration" : "1monthLongTerm",
+         "price" : 22.0
+      }, {
+         "id" : 220691,
+         "duration" : "1monthReservation",
+         "price" : 25.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100247,
+      "title" : "Recklinghausen Hbf P1 Vorplatz Recklinghausen Hbf",
+      "station" : {
+         "id" : 5160,
+         "name" : "Recklinghausen Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "164",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Vorplatz Recklinghausen Hbf",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 7.20332,
+         "latitude" : 51.616723
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000307.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Recklinghausen",
+         "postalCode" : "45657",
+         "street" : "Große-Perdekamp-Straße 21"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "15",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 3 days",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 3 Tage",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220692,
+         "duration" : "20min"
+      }, {
+         "id" : 220693,
+         "duration" : "30min",
+         "price" : 0.75
+      }, {
+         "id" : 220694,
+         "duration" : "1hour",
+         "price" : 1.5
+      }, {
+         "id" : 220695,
+         "duration" : "1day",
+         "price" : 10.0
+      }, {
+         "id" : 220696,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220697,
+         "duration" : "1week"
+      }, {
+         "id" : 220698,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220699,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220700,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 220701,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100248,
+      "title" : "Regensburg Hbf P1 Vorfahrt Regensburg Hbf rechts",
+      "station" : {
+         "id" : 5169,
+         "name" : "Regensburg Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "168",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Vorfahrt Regensburg Hbf rechts",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 12.098552,
+         "latitude" : 49.012361
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000309.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Regensburg",
+         "postalCode" : "93047",
+         "street" : "Bahnhofstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "7",
+      "numberHandicapedPlaces" : "1",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 hours",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Stunden",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220702,
+         "duration" : "20min"
+      }, {
+         "id" : 220703,
+         "duration" : "30min",
+         "price" : 1.1
+      }, {
+         "id" : 220704,
+         "duration" : "1hour",
+         "price" : 2.2
+      }, {
+         "id" : 220705,
+         "duration" : "1day"
+      }, {
+         "id" : 220706,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220707,
+         "duration" : "1week"
+      }, {
+         "id" : 220708,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220709,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220710,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 220711,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100249,
+      "title" : "Regensburg Hbf P2 Vorfahrt Regensburg Hbf",
+      "station" : {
+         "id" : 5169,
+         "name" : "Regensburg Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "167",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Vorfahrt Regensburg Hbf",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 12.100109,
+         "latitude" : 49.012395
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000309.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Regensburg",
+         "postalCode" : "93047",
+         "street" : "Bahnhofstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "17",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 4 hours",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 4 Stunden",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220712,
+         "duration" : "20min"
+      }, {
+         "id" : 220713,
+         "duration" : "30min",
+         "price" : 1.1
+      }, {
+         "id" : 220714,
+         "duration" : "1hour",
+         "price" : 2.2
+      }, {
+         "id" : 220715,
+         "duration" : "1day"
+      }, {
+         "id" : 220716,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220717,
+         "duration" : "1week"
+      }, {
+         "id" : 220718,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220719,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220720,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 220721,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100250,
+      "title" : "Regensburg Hbf P3 Vorfahrt Regensburg Hbf links",
+      "station" : {
+         "id" : 5169,
+         "name" : "Regensburg Hbf"
+      },
+      "label" : "P3",
+      "spaceNumber" : "238",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Vorfahrt Regensburg Hbf links",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 12.100925,
+         "latitude" : 49.012363
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000309.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Regensburg",
+         "postalCode" : "93047",
+         "street" : "Bahnhofstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "41",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 3 days",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 3 Tage",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220722,
+         "duration" : "20min"
+      }, {
+         "id" : 220723,
+         "duration" : "30min",
+         "price" : 1.1
+      }, {
+         "id" : 220724,
+         "duration" : "1hour",
+         "price" : 2.2
+      }, {
+         "id" : 220725,
+         "duration" : "1day",
+         "price" : 8.0
+      }, {
+         "id" : 220726,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220727,
+         "duration" : "1week"
+      }, {
+         "id" : 220728,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220729,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220730,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 220731,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100251,
+      "title" : "Regensburg Hbf P4 Parkplatz Regensburg Hbf",
+      "station" : {
+         "id" : 5169,
+         "name" : "Regensburg Hbf"
+      },
+      "label" : "P4",
+      "spaceNumber" : "165",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Regensburg Hbf",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 12.101492,
+         "latitude" : 49.01243
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000309.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Regensburg",
+         "postalCode" : "93047",
+         "street" : "Bahnhofstraße 18"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "19",
+      "numberHandicapedPlaces" : "1",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Woche",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220732,
+         "duration" : "20min"
+      }, {
+         "id" : 220733,
+         "duration" : "30min"
+      }, {
+         "id" : 220734,
+         "duration" : "1hour",
+         "price" : 2.0
+      }, {
+         "id" : 220735,
+         "duration" : "1day",
+         "price" : 8.0
+      }, {
+         "id" : 220736,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220737,
+         "duration" : "1week",
+         "price" : 32.0
+      }, {
+         "id" : 220738,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220739,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220740,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 220741,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100252,
+      "title" : "Regensburg Hbf P5 Regensburg Hbf P5 Tiefgarage Hbf / Castra Regina Center",
+      "station" : {
+         "id" : 5169,
+         "name" : "Regensburg Hbf"
+      },
+      "label" : "P5",
+      "spaceNumber" : "333",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Tiefgarage Hauptbahnhof / Castra Regina Center",
+      "nameDisplay" : "Regensburg Hbf P5 Tiefgarage Hbf / Castra Regina Center",
+      "spaceType" : "Tiefgarage",
+      "spaceTypeEn" : "Underground car park",
+      "spaceTypeName" : "Tiefgarage",
+      "geoLocation" : {
+         "longitude" : 12.102167,
+         "latitude" : 49.012488
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000309.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Regensburg",
+         "postalCode" : "93047",
+         "street" : "Bahnhofstraße 24"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "409",
+      "numberHandicapedPlaces" : "4",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "260",
+         "clearanceHeight" : "200",
+         "locationNightAccess" : "Nachtzugang über Hotel möglich",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : true,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : true,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffDiscount" : "Bonierung an der DB Information oder im DB Reisezentrum. Zahlung anschließend am Kassenautomaten. Rabattierung mit BahnCard direkt am Kassenautomaten.",
+         "tariffFreeParkingTime" : "nein",
+         "tariffSpecialEn" : "Each additional hour: 2.00",
+         "tariffSpecial" : "je weitere Stunde: 2,00",
+         "tariffDiscountEn" : "Reduction from the DB Information or the DB Reisezentrum (travel centre). Then pay at the pay station. BahnCard discount available directly at the pay station.",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA)",
+         "tariffPointOfSale" : "Park&Rail-Karten erhältlich an allen Verkaufsstellen der Deutschen Bahn (außer Internet).",
+         "tariffPointOfSaleEn" : "Park&Rail cards available from all Deutsche Bahn points of sale (except online).  ",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA)"
+      },
+      "tariffPrices" : [ {
+         "id" : 220742,
+         "duration" : "20min"
+      }, {
+         "id" : 220743,
+         "duration" : "30min",
+         "price" : 1.0
+      }, {
+         "id" : 220744,
+         "duration" : "1hour",
+         "price" : 2.0
+      }, {
+         "id" : 220745,
+         "duration" : "1day",
+         "price" : 12.0
+      }, {
+         "id" : 220746,
+         "duration" : "1dayDiscount",
+         "price" : 10.0
+      }, {
+         "id" : 220747,
+         "duration" : "1week"
+      }, {
+         "id" : 220748,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220749,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220750,
+         "duration" : "1monthLongTerm",
+         "price" : 75.0
+      }, {
+         "id" : 220751,
+         "duration" : "1monthReservation",
+         "price" : 120.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100253,
+      "title" : "Regensburg Hbf P6 Parkplatz Regensburg Hbf Sternbergstraße",
+      "station" : {
+         "id" : 5169,
+         "name" : "Regensburg Hbf"
+      },
+      "label" : "P6",
+      "spaceNumber" : "166",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Regensburg Hbf Sternbergstraße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 12.103526,
+         "latitude" : 49.011477
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000309.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Regensburg",
+         "postalCode" : "93047",
+         "street" : "Sternbergstraße"
+      },
+      "distance" : "150-199",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "101",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "270",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 30 days from the parking ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 30 Tage am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220752,
+         "duration" : "20min"
+      }, {
+         "id" : 220753,
+         "duration" : "30min"
+      }, {
+         "id" : 220754,
+         "duration" : "1hour"
+      }, {
+         "id" : 220755,
+         "duration" : "1day",
+         "price" : 2.5
+      }, {
+         "id" : 220756,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220757,
+         "duration" : "1week",
+         "price" : 17.5
+      }, {
+         "id" : 220758,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220759,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220760,
+         "duration" : "1monthLongTerm",
+         "price" : 55.0
+      }, {
+         "id" : 220761,
+         "duration" : "1monthReservation",
+         "price" : 75.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100254,
+      "title" : "Rheine P1 Vorplatz Bahnhof Rheine",
+      "station" : {
+         "id" : 5251,
+         "name" : "Rheine"
+      },
+      "label" : "P1",
+      "spaceNumber" : "170",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Vorplatz Bahnhof Rheine",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 7.435473,
+         "latitude" : 52.276321
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000316.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Rheine",
+         "postalCode" : "48431",
+         "street" : "Kardinal-Galen-Ring"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "30",
+      "numberHandicapedPlaces" : "1",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 3 days",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 3 Tage",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220762,
+         "duration" : "20min"
+      }, {
+         "id" : 220763,
+         "duration" : "30min",
+         "price" : 0.7
+      }, {
+         "id" : 220764,
+         "duration" : "1hour",
+         "price" : 1.4
+      }, {
+         "id" : 220765,
+         "duration" : "1day",
+         "price" : 4.8
+      }, {
+         "id" : 220766,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220767,
+         "duration" : "1week"
+      }, {
+         "id" : 220768,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220769,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220770,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 220771,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100255,
+      "title" : "Riesa P1 Parkplatz Bahnhof Riesa",
+      "station" : {
+         "id" : 5276,
+         "name" : "Riesa"
+      },
+      "label" : "P1",
+      "spaceNumber" : "171",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Riesa",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 13.286473,
+         "latitude" : 51.309029
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8010297.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Riesa",
+         "postalCode" : "01587",
+         "street" : "Bahnhofstraße"
+      },
+      "distance" : "100-149",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "35",
+      "numberHandicapedPlaces" : "2",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 8 days or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 8 Tage oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 220772,
+         "duration" : "20min"
+      }, {
+         "id" : 220773,
+         "duration" : "30min",
+         "price" : 0.5
+      }, {
+         "id" : 220774,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 220775,
+         "duration" : "1day",
+         "price" : 2.5
+      }, {
+         "id" : 220776,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220777,
+         "duration" : "1week",
+         "price" : 10.0
+      }, {
+         "id" : 220778,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220779,
+         "duration" : "1monthVendingMachine",
+         "price" : 15.0
+      }, {
+         "id" : 220780,
+         "duration" : "1monthLongTerm",
+         "price" : 15.0
+      }, {
+         "id" : 220781,
+         "duration" : "1monthReservation",
+         "price" : 25.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100256,
+      "title" : "Saarbrücken Hbf P1 Vorfahrt Saarbrücken Hbf",
+      "station" : {
+         "id" : 5451,
+         "name" : "Saarbrücken Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "178",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Kurzzeitparkplatz Süd",
+      "nameDisplay" : "Vorfahrt Saarbrücken Hbf",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 6.990164,
+         "latitude" : 49.240564
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000323.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Saarbrücken",
+         "postalCode" : "66111",
+         "street" : "Am Hauptbahnhof 4"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "53",
+      "numberHandicapedPlaces" : "3",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "400",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 day",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Tag",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220782,
+         "duration" : "20min"
+      }, {
+         "id" : 220783,
+         "duration" : "30min",
+         "price" : 1.1
+      }, {
+         "id" : 220784,
+         "duration" : "1hour",
+         "price" : 2.2
+      }, {
+         "id" : 220785,
+         "duration" : "1day",
+         "price" : 20.0
+      }, {
+         "id" : 220786,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220787,
+         "duration" : "1week"
+      }, {
+         "id" : 220788,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220789,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220790,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 220791,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100257,
+      "title" : "Saarbrücken Hbf P2 Parkplatz Saarbrücken Hbf Viktoriastraße",
+      "station" : {
+         "id" : 5451,
+         "name" : "Saarbrücken Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "179",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Saarbrücken Hbf Viktoriastraße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 6.992471,
+         "latitude" : 49.239765
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000323.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Saarbrücken",
+         "postalCode" : "66111",
+         "street" : "Viktoriastraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "44",
+      "numberHandicapedPlaces" : "2",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "400",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Woche",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220792,
+         "duration" : "20min"
+      }, {
+         "id" : 220793,
+         "duration" : "30min"
+      }, {
+         "id" : 220794,
+         "duration" : "1hour",
+         "price" : 2.5
+      }, {
+         "id" : 220795,
+         "duration" : "1day",
+         "price" : 10.0
+      }, {
+         "id" : 220796,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220797,
+         "duration" : "1week",
+         "price" : 45.0
+      }, {
+         "id" : 220798,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220799,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220800,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 220801,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100259,
+      "title" : "Saarbrücken Hbf P4 Parkplatz Saarbrücken Hbf am Gleis",
+      "station" : {
+         "id" : 5451,
+         "name" : "Saarbrücken Hbf"
+      },
+      "label" : "P4",
+      "spaceNumber" : "177",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Saarbrücken Hbf am Gleis",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 6.993225,
+         "latitude" : 49.24073
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000323.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Saarbrücken",
+         "postalCode" : "66111",
+         "street" : "Viktoriastraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "78",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "400",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "ja"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : true,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 9 days or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffPointOfSale" : "Park&Rail-Karten erhältlich an allen Verkaufsstellen der Deutschen Bahn (außer Internet).",
+         "tariffPointOfSaleEn" : "Park&Rail cards available from all Deutsche Bahn points of sale (except online).  ",
+         "tariffMaxParkingTime" : "Max. 9 Tage oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220802,
+         "duration" : "20min"
+      }, {
+         "id" : 220803,
+         "duration" : "30min",
+         "price" : 1.1
+      }, {
+         "id" : 220804,
+         "duration" : "1hour",
+         "price" : 2.2
+      }, {
+         "id" : 220805,
+         "duration" : "1day",
+         "price" : 8.8
+      }, {
+         "id" : 220806,
+         "duration" : "1dayDiscount",
+         "price" : 6.6
+      }, {
+         "id" : 220807,
+         "duration" : "1week",
+         "price" : 44.0
+      }, {
+         "id" : 220808,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220809,
+         "duration" : "1monthVendingMachine",
+         "price" : 70.0
+      }, {
+         "id" : 220810,
+         "duration" : "1monthLongTerm",
+         "price" : 70.0
+      }, {
+         "id" : 220811,
+         "duration" : "1monthReservation",
+         "price" : 110.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100260,
+      "title" : "Saarbrücken Hbf P5 Saarbrücken Hbf Viktoriastraße",
+      "station" : {
+         "id" : 5451,
+         "name" : "Saarbrücken Hbf"
+      },
+      "label" : "P5",
+      "spaceNumber" : "360",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Saarbrücken Hbf Viktoriastraße",
+      "spaceType" : "Straße",
+      "spaceTypeEn" : "On-street parking",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 6.993238,
+         "latitude" : 49.240129
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000323.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Saarbrücken",
+         "postalCode" : "66111",
+         "street" : "Viktoriastraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "7",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "400",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 day",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Tag",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220812,
+         "duration" : "20min"
+      }, {
+         "id" : 220813,
+         "duration" : "30min"
+      }, {
+         "id" : 220814,
+         "duration" : "1hour",
+         "price" : 2.5
+      }, {
+         "id" : 220815,
+         "duration" : "1day",
+         "price" : 10.0
+      }, {
+         "id" : 220816,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220817,
+         "duration" : "1week"
+      }, {
+         "id" : 220818,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220819,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220820,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 220821,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100261,
+      "title" : "Schlüchtern P1 Parkplatz Bahnhof Schlüchtern",
+      "station" : {
+         "id" : 5601,
+         "name" : "Schlüchtern"
+      },
+      "label" : "P1",
+      "spaceNumber" : "180",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Schlüchtern",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.509042,
+         "latitude" : 50.340624
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000891.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Schlüchtern",
+         "postalCode" : "36381",
+         "street" : "Am Bahnhof"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "200",
+      "numberHandicapedPlaces" : "2",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "260",
+         "clearanceHeight" : "300",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220822,
+         "duration" : "20min"
+      }, {
+         "id" : 220823,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 220824,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 220825,
+         "duration" : "1day",
+         "price" : 2.6
+      }, {
+         "id" : 220826,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220827,
+         "duration" : "1week",
+         "price" : 10.4
+      }, {
+         "id" : 220828,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220829,
+         "duration" : "1monthVendingMachine",
+         "price" : 24.0
+      }, {
+         "id" : 220830,
+         "duration" : "1monthLongTerm",
+         "price" : 24.0
+      }, {
+         "id" : 220831,
+         "duration" : "1monthReservation",
+         "price" : 40.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100262,
+      "title" : "Schlüchtern P2 Parkplatz Bahnhof Schlüchtern",
+      "station" : {
+         "id" : 5601,
+         "name" : "Schlüchtern"
+      },
+      "label" : "P2",
+      "spaceNumber" : "181",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Schlüchtern",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.510537,
+         "latitude" : 50.340972
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000891.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Schlüchtern",
+         "postalCode" : "36381",
+         "street" : "Am Bahnhof"
+      },
+      "distance" : "100-149",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "235",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "clearanceHeight" : "300",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220832,
+         "duration" : "20min"
+      }, {
+         "id" : 220833,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 220834,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 220835,
+         "duration" : "1day",
+         "price" : 2.6
+      }, {
+         "id" : 220836,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220837,
+         "duration" : "1week",
+         "price" : 10.4
+      }, {
+         "id" : 220838,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220839,
+         "duration" : "1monthVendingMachine",
+         "price" : 24.0
+      }, {
+         "id" : 220840,
+         "duration" : "1monthLongTerm",
+         "price" : 24.0
+      }, {
+         "id" : 220841,
+         "duration" : "1monthReservation",
+         "price" : 40.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100263,
+      "title" : "Schwandorf P1 Parkplatz Bahnhof Schwandorf",
+      "station" : {
+         "id" : 5710,
+         "name" : "Schwandorf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "183",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Schwandorf",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 12.103842,
+         "latitude" : 49.327116
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000027.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Schwandorf",
+         "postalCode" : "92421",
+         "street" : "Bahnhofplatz"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "20",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 3 days",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 3 Tage",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220852,
+         "duration" : "20min"
+      }, {
+         "id" : 220853,
+         "duration" : "30min"
+      }, {
+         "id" : 220854,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 220855,
+         "duration" : "1day",
+         "price" : 3.2
+      }, {
+         "id" : 220856,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220857,
+         "duration" : "1week"
+      }, {
+         "id" : 220858,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220859,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220860,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 220861,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100264,
+      "title" : "Schweinfurt Hbf P1 Parkplatz Schweinfurt Hbf links",
+      "station" : {
+         "id" : 5742,
+         "name" : "Schweinfurt Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "184",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Schweinfurt Hbf links",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 10.213094,
+         "latitude" : 50.035711
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000032.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Schweinfurt",
+         "postalCode" : "97424",
+         "street" : "Hauptbahnhofstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "numberParkingPlaces" : "8",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : true,
+      "outOfServiceText" : "Baustelleneinrichtung. Zurzeit keine Parkmöglichkeit.",
+      "outOfServiceTextEn" : "Construction site. No parking at the moment.",
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+      },
+      "tariffInfo" : {
+      },
+      "tariffPrices" : [ ]
+   }, {
+      "type" : "space",
+      "id" : 100265,
+      "title" : "Schweinfurt Hbf P2 Parkplatz Schweinfurt Hbf rechts",
+      "station" : {
+         "id" : 5742,
+         "name" : "Schweinfurt Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "185",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Schweinfurt Hbf rechts",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 10.210229,
+         "latitude" : 50.035242
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000032.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Schweinfurt",
+         "postalCode" : "97424",
+         "street" : "Gustav-Heusinger-Straße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "95",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 9 days or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 9 Tage oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 220872,
+         "duration" : "20min"
+      }, {
+         "id" : 220873,
+         "duration" : "30min",
+         "price" : 0.5
+      }, {
+         "id" : 220874,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 220875,
+         "duration" : "1day",
+         "price" : 4.5
+      }, {
+         "id" : 220876,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220877,
+         "duration" : "1week",
+         "price" : 18.0
+      }, {
+         "id" : 220878,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220879,
+         "duration" : "1monthVendingMachine",
+         "price" : 30.0
+      }, {
+         "id" : 220880,
+         "duration" : "1monthLongTerm",
+         "price" : 30.0
+      }, {
+         "id" : 220881,
+         "duration" : "1monthReservation",
+         "price" : 45.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100266,
+      "title" : "Schwerin Hbf P1 Parkplatz Schwerin Hbf Rückseite",
+      "station" : {
+         "id" : 5755,
+         "name" : "Schwerin Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "186",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Schwerin Hbf Rückseite",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 11.406828,
+         "latitude" : 53.634099
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8010324.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Schwerin",
+         "postalCode" : "19053",
+         "street" : "Zum Bahnhof"
+      },
+      "distance" : "150-199",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "18",
+      "numberHandicapedPlaces" : "2",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week from the parking ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 1 Woche am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 220882,
+         "duration" : "20min"
+      }, {
+         "id" : 220883,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 220884,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 220885,
+         "duration" : "1day",
+         "price" : 4.5
+      }, {
+         "id" : 220886,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220887,
+         "duration" : "1week",
+         "price" : 18.0
+      }, {
+         "id" : 220888,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220889,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220890,
+         "duration" : "1monthLongTerm",
+         "price" : 60.0
+      }, {
+         "id" : 220891,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100267,
+      "title" : "Siegen P1 Parkplatz Siegen Morleystraße",
+      "station" : {
+         "id" : 5842,
+         "name" : "Siegen"
+      },
+      "label" : "P1",
+      "spaceNumber" : "295",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Siegen Morleystraße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.014856,
+         "latitude" : 50.873405
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000046.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Siegen",
+         "postalCode" : "57072",
+         "street" : "Morleystraße"
+      },
+      "distance" : "250",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "82",
+      "numberHandicapedPlaces" : "1",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220892,
+         "duration" : "20min"
+      }, {
+         "id" : 220893,
+         "duration" : "30min"
+      }, {
+         "id" : 220894,
+         "duration" : "1hour",
+         "price" : 1.5
+      }, {
+         "id" : 220895,
+         "duration" : "1day",
+         "price" : 8.5
+      }, {
+         "id" : 220896,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220897,
+         "duration" : "1week",
+         "price" : 42.5
+      }, {
+         "id" : 220898,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220899,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220900,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 220901,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100268,
+      "title" : "Singen (Hohentwiel) P1 Parkplatz Bahnhof Singen (Hohentwiel)",
+      "station" : {
+         "id" : 5865,
+         "name" : "Singen (Hohentwiel)"
+      },
+      "label" : "P1",
+      "spaceNumber" : "188",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Singen (Hohentwiel)",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.84241,
+         "latitude" : 47.759793
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000073.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Singen (Hohentwiel)",
+         "postalCode" : "78224",
+         "street" : "Bahnhofstraße"
+      },
+      "distance" : "150-199",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "76",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "229.99999999999997",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 4 weeks from the ticket machine",
+         "tariffSpecialEn" : "4 weeks ticket (28 days): 28.00",
+         "tariffSpecial" : "4-Wochen-Parkschein (28 Tage): 28,00",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 4 Wochen am Automaten",
+         "tarifNotesEn" : "The city's parking tickets are not valid in this area. ",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffNotes" : "Parkscheine der Stadt haben auf dieser Fläche keine Gültigkeit.",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 220902,
+         "duration" : "20min"
+      }, {
+         "id" : 220903,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 220904,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 220905,
+         "duration" : "1day",
+         "price" : 3.2
+      }, {
+         "id" : 220906,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220907,
+         "duration" : "1week",
+         "price" : 12.8
+      }, {
+         "id" : 220908,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220909,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220910,
+         "duration" : "1monthLongTerm",
+         "price" : 40.0
+      }, {
+         "id" : 220911,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100269,
+      "title" : "Steinau (Straße) P1 Parkplatz Bahnhof Steinau",
+      "station" : {
+         "id" : 5986,
+         "name" : "Steinau (Straße)"
+      },
+      "label" : "P1",
+      "spaceNumber" : "219",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Steinau",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.444647,
+         "latitude" : 50.314117
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8005690.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Steinau an der Straße",
+         "postalCode" : "36396",
+         "street" : "Bahnhofstraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "65",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "clearanceHeight" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 220912,
+         "duration" : "20min"
+      }, {
+         "id" : 220913,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 220914,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 220915,
+         "duration" : "1day",
+         "price" : 2.6
+      }, {
+         "id" : 220916,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220917,
+         "duration" : "1week",
+         "price" : 10.4
+      }, {
+         "id" : 220918,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220919,
+         "duration" : "1monthVendingMachine",
+         "price" : 24.0
+      }, {
+         "id" : 220920,
+         "duration" : "1monthLongTerm",
+         "price" : 24.0
+      }, {
+         "id" : 220921,
+         "duration" : "1monthReservation",
+         "price" : 40.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100270,
+      "title" : "Steinau (Straße) P2 Parkplatz Bahnhof Steinau Rückseite",
+      "station" : {
+         "id" : 5986,
+         "name" : "Steinau (Straße)"
+      },
+      "label" : "P2",
+      "spaceNumber" : "234",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Steinau Rückseite",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.442472,
+         "latitude" : 50.314554
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8005690.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Steinau an der Straße",
+         "postalCode" : "36396",
+         "street" : "Marborner Straße"
+      },
+      "distance" : "100-149",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "75",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "clearanceHeight" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 220922,
+         "duration" : "20min"
+      }, {
+         "id" : 220923,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 220924,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 220925,
+         "duration" : "1day",
+         "price" : 2.6
+      }, {
+         "id" : 220926,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220927,
+         "duration" : "1week",
+         "price" : 10.4
+      }, {
+         "id" : 220928,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220929,
+         "duration" : "1monthVendingMachine",
+         "price" : 24.0
+      }, {
+         "id" : 220930,
+         "duration" : "1monthLongTerm",
+         "price" : 24.0
+      }, {
+         "id" : 220931,
+         "duration" : "1monthReservation",
+         "price" : 40.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100271,
+      "title" : "Stendal P1 Parkplatz Bahnhof Stendal rechts",
+      "station" : {
+         "id" : 6010,
+         "name" : "Stendal"
+      },
+      "label" : "P1",
+      "spaceNumber" : "261",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Stendal rechts",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 11.853261,
+         "latitude" : 52.594989
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8010334.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Stendal",
+         "postalCode" : "39576",
+         "street" : "Bahnhofstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "74",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "340",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 220932,
+         "duration" : "20min"
+      }, {
+         "id" : 220933,
+         "duration" : "30min"
+      }, {
+         "id" : 220934,
+         "duration" : "1hour",
+         "price" : 0.5
+      }, {
+         "id" : 220935,
+         "duration" : "1day",
+         "price" : 2.0
+      }, {
+         "id" : 220936,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220937,
+         "duration" : "1week",
+         "price" : 10.0
+      }, {
+         "id" : 220938,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220939,
+         "duration" : "1monthVendingMachine",
+         "price" : 30.0
+      }, {
+         "id" : 220940,
+         "duration" : "1monthLongTerm",
+         "price" : 30.0
+      }, {
+         "id" : 220941,
+         "duration" : "1monthReservation",
+         "price" : 40.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100272,
+      "title" : "Stralsund Hbf P1 Vorfahrt Stralsund Hbf",
+      "station" : {
+         "id" : 6049,
+         "name" : "Stralsund Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "189",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Vorfahrt Stralsund Hbf",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 13.077329,
+         "latitude" : 54.309057
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8010338.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Stralsund",
+         "postalCode" : "18437",
+         "street" : "Tribseer Damm"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "11",
+      "numberHandicapedPlaces" : "1",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "550",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 hours",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Stunden",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220942,
+         "duration" : "20min"
+      }, {
+         "id" : 220943,
+         "duration" : "30min",
+         "price" : 0.7
+      }, {
+         "id" : 220944,
+         "duration" : "1hour",
+         "price" : 1.4
+      }, {
+         "id" : 220945,
+         "duration" : "1day"
+      }, {
+         "id" : 220946,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220947,
+         "duration" : "1week"
+      }, {
+         "id" : 220948,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220949,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220950,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 220951,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100273,
+      "title" : "Straubing P1 Vorfahrt Bahnhof Straubing",
+      "station" : {
+         "id" : 6056,
+         "name" : "Straubing"
+      },
+      "label" : "P1",
+      "spaceNumber" : "191",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Vorfahrt Bahnhof Straubing",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 12.574244,
+         "latitude" : 48.877317
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000095.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Straubing",
+         "postalCode" : "94315",
+         "street" : "Bahnhofplatz"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "8",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 day",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 1 Tag",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 220952,
+         "duration" : "20min"
+      }, {
+         "id" : 220953,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 220954,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 220955,
+         "duration" : "1day",
+         "price" : 5.0
+      }, {
+         "id" : 220956,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220957,
+         "duration" : "1week"
+      }, {
+         "id" : 220958,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220959,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220960,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 220961,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100274,
+      "title" : "Straubing P2 Parkplatz Bahnhof Straubing links",
+      "station" : {
+         "id" : 6056,
+         "name" : "Straubing"
+      },
+      "label" : "P2",
+      "spaceNumber" : "190",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Straubing links",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 12.57473,
+         "latitude" : 48.877124
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000095.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Straubing",
+         "postalCode" : "94315",
+         "street" : "Bahnhofplatz"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "18",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 3 days",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 3 Tage",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 220962,
+         "duration" : "20min"
+      }, {
+         "id" : 220963,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 220964,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 220965,
+         "duration" : "1day",
+         "price" : 5.0
+      }, {
+         "id" : 220966,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220967,
+         "duration" : "1week"
+      }, {
+         "id" : 220968,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220969,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220970,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 220971,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100275,
+      "title" : "Stuttgart Hbf P1 Stuttgart Hbf P1 Tiefgarage LBBW",
+      "station" : {
+         "id" : 6071,
+         "name" : "Stuttgart Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "227",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Tiefgarage LBBW",
+      "nameDisplay" : "Stuttgart Hbf P1 Tiefgarage LBBW",
+      "spaceType" : "Tiefgarage",
+      "spaceTypeEn" : "Underground car park",
+      "spaceTypeName" : "Tiefgarage",
+      "geoLocation" : {
+         "longitude" : 9.18133,
+         "latitude" : 48.786446
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000096.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Stuttgart",
+         "postalCode" : "70173",
+         "street" : "Am Hauptbahnhof 2"
+      },
+      "distance" : "<50",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "1287",
+      "numberHandicapedPlaces" : "41",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "330",
+         "clearanceHeight" : "200",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : true,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : true,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffDiscount" : "Rabattierung mit BahnCard direkt am Kassenautomaten. Bonierung an der DB Information.",
+         "tariffFreeParkingTime" : "nein",
+         "tariffDiscountEn" : "BahnCard discount available directly at the pay station. Reduction from the DB Information.",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA), EC-Karte, P Card",
+         "tariffPaymentCustomerCards" : "P Card",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA), EC-Card, P Card"
+      },
+      "tariffPrices" : [ {
+         "id" : 220972,
+         "duration" : "20min"
+      }, {
+         "id" : 220973,
+         "duration" : "30min"
+      }, {
+         "id" : 220974,
+         "duration" : "1hour",
+         "price" : 2.5
+      }, {
+         "id" : 220975,
+         "duration" : "1day",
+         "price" : 20.0
+      }, {
+         "id" : 220976,
+         "duration" : "1dayDiscount",
+         "price" : 17.0
+      }, {
+         "id" : 220977,
+         "duration" : "1week"
+      }, {
+         "id" : 220978,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220979,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220980,
+         "duration" : "1monthLongTerm",
+         "price" : 140.0
+      }, {
+         "id" : 220981,
+         "duration" : "1monthReservation",
+         "price" : 180.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100276,
+      "title" : "Stuttgart Hbf P2 Vorplatz Stuttgart Hbf",
+      "station" : {
+         "id" : 6071,
+         "name" : "Stuttgart Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "349",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Kurt-Georg-Kiesinger-Platz",
+      "nameDisplay" : "Vorplatz Stuttgart Hbf",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.180542,
+         "latitude" : 48.784356
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000096.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Stuttgart",
+         "postalCode" : "70173",
+         "street" : "Kurt-Georg-Kiesinger-Platz"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "11",
+      "numberHandicapedPlaces" : "3",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "350",
+         "clearanceHeight" : "350",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 30 mins.",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 30 Minuten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 220992,
+         "duration" : "20min"
+      }, {
+         "id" : 220993,
+         "duration" : "30min",
+         "price" : 1.5
+      }, {
+         "id" : 220994,
+         "duration" : "1hour"
+      }, {
+         "id" : 220995,
+         "duration" : "1day"
+      }, {
+         "id" : 220996,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220997,
+         "duration" : "1week"
+      }, {
+         "id" : 220998,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220999,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 221000,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 221001,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100277,
+      "title" : "Stuttgart Hbf P3 Parkplatz Stuttgart Hbf Jägerstraße",
+      "station" : {
+         "id" : 6071,
+         "name" : "Stuttgart Hbf"
+      },
+      "label" : "P3",
+      "spaceNumber" : "451",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Jägerstraße",
+      "nameDisplay" : "Parkplatz Stuttgart Hbf Jägerstraße",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.17868,
+         "latitude" : 48.786321
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000096.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Stuttgart",
+         "postalCode" : "70174",
+         "street" : "Jägerstraße 14-18"
+      },
+      "distance" : "400",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "37",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 3 days",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 3 Tage",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 220982,
+         "duration" : "20min"
+      }, {
+         "id" : 220983,
+         "duration" : "30min"
+      }, {
+         "id" : 220984,
+         "duration" : "1hour",
+         "price" : 1.5
+      }, {
+         "id" : 220985,
+         "duration" : "1day",
+         "price" : 4.0
+      }, {
+         "id" : 220986,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 220987,
+         "duration" : "1week"
+      }, {
+         "id" : 220988,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 220989,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 220990,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 220991,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100278,
+      "title" : "Stuttgart-Bad Cannstatt P1 Stuttgart-Bad Cannstatt P1 Parkhaus Wilhelmsplatz Ebenen 7 bis 12",
+      "station" : {
+         "id" : 6077,
+         "name" : "Stuttgart-Bad Cannstatt"
+      },
+      "label" : "P1",
+      "spaceNumber" : "457",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkhaus Wilhelmsplatz Ebenen 7 bis 12",
+      "nameDisplay" : "Stuttgart-Bad Cannstatt P1 Parkhaus Wilhelmsplatz Ebenen 7 bis 12",
+      "spaceType" : "Parkhaus",
+      "spaceTypeEn" : "Multi storey car park",
+      "spaceTypeName" : "Parkhaus",
+      "geoLocation" : {
+         "longitude" : 9.216142,
+         "latitude" : 48.802249
+      },
+      "slogan" : "Tiefpreisparken",
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8005769.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Stuttgart",
+         "postalCode" : "70372",
+         "street" : "Eisenbahnstraße 12"
+      },
+      "distance" : "100-149",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "05:00 - 24:00 Uhr, Ausfahrt mit Parkticket jederzeit möglich",
+      "openingHoursEn" : "5:00am - 12:00pm, exit possible at any time with parking ticket",
+      "numberParkingPlaces" : "142",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA, BahnCard-Kreditkarte), EC-Karte, P Card",
+         "tariffPaymentCustomerCards" : "BahnCard, P Card",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA, BahnCard credit card), EC-Card, P Card"
+      },
+      "tariffPrices" : [ {
+         "id" : 912977,
+         "duration" : "20min"
+      }, {
+         "id" : 912978,
+         "duration" : "30min"
+      }, {
+         "id" : 912979,
+         "duration" : "1hour",
+         "price" : 1.5
+      }, {
+         "id" : 912980,
+         "duration" : "1day",
+         "price" : 8.0
+      }, {
+         "id" : 912981,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 912982,
+         "duration" : "1week"
+      }, {
+         "id" : 912983,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 912984,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 912985,
+         "duration" : "1monthLongTerm",
+         "price" : 89.0
+      }, {
+         "id" : 912986,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100279,
+      "title" : "Stuttgart-Bad Cannstatt P2 Stuttgart-Bad Cannstatt P2 Parkhaus Wilhelmsplatz Ebenen -1 bis 6",
+      "station" : {
+         "id" : 6077,
+         "name" : "Stuttgart-Bad Cannstatt"
+      },
+      "label" : "P2",
+      "spaceNumber" : "453",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Ebenen -1 bis 6",
+      "nameDisplay" : "Stuttgart-Bad Cannstatt P2 Parkhaus Wilhelmsplatz Ebenen -1 bis 6",
+      "spaceType" : "Parkhaus",
+      "spaceTypeEn" : "Multi storey car park",
+      "spaceTypeName" : "Parkhaus",
+      "geoLocation" : {
+         "longitude" : 9.216194,
+         "latitude" : 48.802194
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8005769.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Stuttgart",
+         "postalCode" : "70372",
+         "street" : "Eisenbahnstraße 12"
+      },
+      "distance" : "100-149",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "05:00 - 24:00 Uhr, Ausfahrt mit Parkticket jederzeit möglich",
+      "openingHoursEn" : "5:00am - 12:00pm, exit possible at any time with parking ticket",
+      "numberParkingPlaces" : "172",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA, BahnCard-Kreditkarte), EC-Karte, P Card",
+         "tariffPaymentCustomerCards" : "BahnCard, P Card",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA, BahnCard credit card), EC-Card, P Card"
+      },
+      "tariffPrices" : [ {
+         "id" : 221012,
+         "duration" : "20min"
+      }, {
+         "id" : 221013,
+         "duration" : "30min"
+      }, {
+         "id" : 221014,
+         "duration" : "1hour",
+         "price" : 1.5
+      }, {
+         "id" : 221015,
+         "duration" : "1day",
+         "price" : 8.0
+      }, {
+         "id" : 221016,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 221017,
+         "duration" : "1week"
+      }, {
+         "id" : 221018,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221019,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 221020,
+         "duration" : "1monthLongTerm",
+         "price" : 89.0
+      }, {
+         "id" : 221021,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100280,
+      "title" : "Stuttgart-Bad Cannstatt P3 Stuttgart-Bad Cannstatt P3 Parkhaus Wilhelmsplatz Ebenen -3 und -2",
+      "station" : {
+         "id" : 6077,
+         "name" : "Stuttgart-Bad Cannstatt"
+      },
+      "label" : "P3",
+      "spaceNumber" : "458",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Ebenen -3 und -2",
+      "nameDisplay" : "Stuttgart-Bad Cannstatt P3 Parkhaus Wilhelmsplatz Ebenen -3 und -2",
+      "spaceType" : "Parkhaus",
+      "spaceTypeEn" : "Multi storey car park",
+      "spaceTypeName" : "Parkhaus",
+      "geoLocation" : {
+         "longitude" : 9.216243,
+         "latitude" : 48.802139
+      },
+      "slogan" : "Tiefpreisparken",
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8005769.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Stuttgart",
+         "postalCode" : "70372",
+         "street" : "Eisenbahnstraße 12"
+      },
+      "distance" : "100-149",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "05:00 - 24:00 Uhr, Ausfahrt mit Parkticket jederzeit möglich",
+      "openingHoursEn" : "5:00am - 12:00pm, exit possible at any time with parking ticket",
+      "numberParkingPlaces" : "41",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA, BahnCard-Kreditkarte), EC-Karte, P Card",
+         "tariffPaymentCustomerCards" : "BahnCard, P Card",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA, BahnCard credit card), EC-Card, P Card"
+      },
+      "tariffPrices" : [ {
+         "id" : 912987,
+         "duration" : "20min"
+      }, {
+         "id" : 912988,
+         "duration" : "30min"
+      }, {
+         "id" : 912989,
+         "duration" : "1hour",
+         "price" : 1.5
+      }, {
+         "id" : 912990,
+         "duration" : "1day",
+         "price" : 8.0
+      }, {
+         "id" : 912991,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 912992,
+         "duration" : "1week"
+      }, {
+         "id" : 912993,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 912994,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 912995,
+         "duration" : "1monthLongTerm",
+         "price" : 89.0
+      }, {
+         "id" : 912996,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100281,
+      "title" : "Stuttgart-Vaihingen P1 Parkplatz Bahnhof Stuttgart-Vaihingen",
+      "station" : {
+         "id" : 6087,
+         "name" : "Stuttgart-Vaihingen"
+      },
+      "label" : "P1",
+      "spaceNumber" : "455",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Bahnhof Stuttgart-Vaihingen",
+      "nameDisplay" : "Parkplatz Bahnhof Stuttgart-Vaihingen",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.111915,
+         "latitude" : 48.726061
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8005776.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Stuttgart",
+         "postalCode" : "70563",
+         "street" : "Bahnhof (Vaihingen) 1"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "74",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks from the parking ticket machine",
+         "tariffSpecialEn" : "6 month ticket for EUR 102.00 available from the VVS. Limited season parking availabilty.",
+         "tariffSpecial" : "Halbjahreskarten zum Preis von EUR 102,00 über den VVS erhältlich. Begrenzte Verfügbarkeit Dauerparken.",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 221032,
+         "duration" : "20min"
+      }, {
+         "id" : 221033,
+         "duration" : "30min"
+      }, {
+         "id" : 221034,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 221035,
+         "duration" : "1day",
+         "price" : 2.0
+      }, {
+         "id" : 221036,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 221037,
+         "duration" : "1week",
+         "price" : 10.0
+      }, {
+         "id" : 221038,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221039,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 221040,
+         "duration" : "1monthLongTerm",
+         "price" : 17.0
+      }, {
+         "id" : 221041,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100282,
+      "title" : "Stuttgart-Zuffenhausen P1 Parkplatz Bahnhof Stuttgart-Zuffenhausen",
+      "station" : {
+         "id" : 6090,
+         "name" : "Stuttgart-Zuffenhausen"
+      },
+      "label" : "P1",
+      "spaceNumber" : "312",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Stuttgart-Zuffenhausen",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.165506,
+         "latitude" : 48.830276
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8005778.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Stuttgart",
+         "postalCode" : "70435",
+         "street" : "Am Bahnhof"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "23",
+      "numberHandicapedPlaces" : "1",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 day",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Tag",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 221042,
+         "duration" : "20min"
+      }, {
+         "id" : 221043,
+         "duration" : "30min",
+         "price" : 0.5
+      }, {
+         "id" : 221044,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 221045,
+         "duration" : "1day",
+         "price" : 2.6
+      }, {
+         "id" : 221046,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 221047,
+         "duration" : "1week"
+      }, {
+         "id" : 221048,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221049,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 221050,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 221051,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100283,
+      "title" : "Stuttgart-Zuffenhausen P2 Bahnhof Zuffenhausen Dauerparkplatz",
+      "station" : {
+         "id" : 6090,
+         "name" : "Stuttgart-Zuffenhausen"
+      },
+      "label" : "P2",
+      "spaceNumber" : "313",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Bahnhof Zuffenhausen Dauerparkplatz",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.165296,
+         "latitude" : 48.830888
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8005778.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Stuttgart",
+         "postalCode" : "70435",
+         "street" : "Am Bahnhof"
+      },
+      "distance" : "<50",
+      "facilityType" : "keine",
+      "facilityTypeEn" : "none",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "150",
+      "numberHandicapedPlaces" : "1",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffSpecialEn" : "6 month ticket for EUR 180.00 available from the VVS. ",
+         "tariffSpecial" : "Halbjahreskarten zum Preis von EUR 180,00 über den VVS erhältlich.",
+         "tariffFreeParkingTimeEn" : "nein"
+      },
+      "tariffPrices" : [ {
+         "id" : 221052,
+         "duration" : "20min"
+      }, {
+         "id" : 221053,
+         "duration" : "30min"
+      }, {
+         "id" : 221054,
+         "duration" : "1hour"
+      }, {
+         "id" : 221055,
+         "duration" : "1day"
+      }, {
+         "id" : 221056,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 221057,
+         "duration" : "1week"
+      }, {
+         "id" : 221058,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221059,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 221060,
+         "duration" : "1monthLongTerm",
+         "price" : 40.0
+      }, {
+         "id" : 221061,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100284,
+      "title" : "Stuttgart-Zuffenhausen P3 Bahnhof Zuffenhausen Straßenparkplatz",
+      "station" : {
+         "id" : 6090,
+         "name" : "Stuttgart-Zuffenhausen"
+      },
+      "label" : "P3",
+      "spaceNumber" : "334",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Bahnhof Zuffenhausen Straßenparkplatz",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.165245,
+         "latitude" : 48.831285
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8005778.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Stuttgart",
+         "postalCode" : "70435",
+         "street" : "Am Bahnhof"
+      },
+      "distance" : "0-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "35",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 3 days",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 3 Tage",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 221062,
+         "duration" : "20min"
+      }, {
+         "id" : 221063,
+         "duration" : "30min",
+         "price" : 0.5
+      }, {
+         "id" : 221064,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 221065,
+         "duration" : "1day",
+         "price" : 2.6
+      }, {
+         "id" : 221066,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 221067,
+         "duration" : "1week"
+      }, {
+         "id" : 221068,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221069,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 221070,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 221071,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100286,
+      "title" : "Treysa P1 Parkplatz Bahnhof Treysa",
+      "station" : {
+         "id" : 6256,
+         "name" : "Treysa"
+      },
+      "label" : "P1",
+      "spaceNumber" : "192",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Treysa",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.18634,
+         "latitude" : 50.91092
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000129.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Schwalmstadt-Treysa",
+         "postalCode" : "34613",
+         "street" : "Bahnhofstraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "48",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "clearanceHeight" : "300",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 221072,
+         "duration" : "20min"
+      }, {
+         "id" : 221073,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 221074,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 221075,
+         "duration" : "1day",
+         "price" : 2.8
+      }, {
+         "id" : 221076,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 221077,
+         "duration" : "1week",
+         "price" : 11.2
+      }, {
+         "id" : 221078,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221079,
+         "duration" : "1monthVendingMachine",
+         "price" : 35.0
+      }, {
+         "id" : 221080,
+         "duration" : "1monthLongTerm",
+         "price" : 35.0
+      }, {
+         "id" : 221081,
+         "duration" : "1monthReservation",
+         "price" : 50.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100287,
+      "title" : "Trier Hbf P1 Vorfahrt Trier Hbf",
+      "station" : {
+         "id" : 6264,
+         "name" : "Trier Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "193",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Vorfahrt Trier Hbf",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 6.651553,
+         "latitude" : 49.756924
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000134.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Trier",
+         "postalCode" : "54292",
+         "street" : "Bahnhofsplatz"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "9",
+      "numberHandicapedPlaces" : "1",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "400",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 4 hours",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 4 Stunden",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 221082,
+         "duration" : "20min"
+      }, {
+         "id" : 221083,
+         "duration" : "30min",
+         "price" : 1.0
+      }, {
+         "id" : 221084,
+         "duration" : "1hour",
+         "price" : 2.0
+      }, {
+         "id" : 221085,
+         "duration" : "1day"
+      }, {
+         "id" : 221086,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 221087,
+         "duration" : "1week"
+      }, {
+         "id" : 221088,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221089,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 221090,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 221091,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100288,
+      "title" : "Trier Hbf P2 ParkplatzTrier Hbf links",
+      "station" : {
+         "id" : 6264,
+         "name" : "Trier Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "196",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "ParkplatzTrier Hbf links",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 6.652917,
+         "latitude" : 49.757948
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000134.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Trier",
+         "postalCode" : "54292",
+         "street" : "Kürenzer Straße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "9",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Woche",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 221092,
+         "duration" : "20min"
+      }, {
+         "id" : 221093,
+         "duration" : "30min",
+         "price" : 1.0
+      }, {
+         "id" : 221094,
+         "duration" : "1hour",
+         "price" : 2.0
+      }, {
+         "id" : 221095,
+         "duration" : "1day",
+         "price" : 10.0
+      }, {
+         "id" : 221096,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 221097,
+         "duration" : "1week",
+         "price" : 40.0
+      }, {
+         "id" : 221098,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221099,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 221100,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 221101,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100289,
+      "title" : "Troisdorf P1 Parkplatz Bahnhof Troisdorf",
+      "station" : {
+         "id" : 6273,
+         "name" : "Troisdorf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "425",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Bahnhof Troisdorf",
+      "nameDisplay" : "Parkplatz Bahnhof Troisdorf",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 7.148731,
+         "latitude" : 50.813557
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000135.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Troisdorf",
+         "postalCode" : "53842",
+         "street" : "Bahnstraße/Sieglarer Straße"
+      },
+      "distance" : "100-149",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "170",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 221102,
+         "duration" : "20min"
+      }, {
+         "id" : 221103,
+         "duration" : "30min"
+      }, {
+         "id" : 221104,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 221105,
+         "duration" : "1day",
+         "price" : 2.0
+      }, {
+         "id" : 221106,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 221107,
+         "duration" : "1week",
+         "price" : 10.0
+      }, {
+         "id" : 221108,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221109,
+         "duration" : "1monthVendingMachine",
+         "price" : 30.0
+      }, {
+         "id" : 221110,
+         "duration" : "1monthLongTerm",
+         "price" : 30.0
+      }, {
+         "id" : 221111,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100285,
+      "title" : "Tübingen Hbf P1 Parkplatz Tübingen Hbf",
+      "station" : {
+         "id" : 6279,
+         "name" : "Tübingen Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "197",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Tübingen Hbf",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.056824,
+         "latitude" : 48.515235
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000141.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Tübingen",
+         "postalCode" : "72072",
+         "street" : "Hegelstraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "56",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "400",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 1 Woche",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 221112,
+         "duration" : "20min"
+      }, {
+         "id" : 221113,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 221114,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 221115,
+         "duration" : "1day",
+         "price" : 5.0
+      }, {
+         "id" : 221116,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 221117,
+         "duration" : "1week",
+         "price" : 25.0
+      }, {
+         "id" : 221118,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221119,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 221120,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 221121,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100290,
+      "title" : "Ulm Hbf P1 Kurzzeitparkplatz Ulm Hbf",
+      "station" : {
+         "id" : 6323,
+         "name" : "Ulm Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "198",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Kurzzeitparkplatz Ulm Hbf",
+      "nameDisplay" : "Kurzzeitparkplatz Ulm Hbf",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.98338,
+         "latitude" : 48.40016
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000170.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Ulm",
+         "postalCode" : "89073",
+         "street" : "Friedrich-Ebert-Straße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "30",
+      "numberHandicapedPlaces" : "1",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 day",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 1 Tag",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 221122,
+         "duration" : "20min"
+      }, {
+         "id" : 221123,
+         "duration" : "30min",
+         "price" : 1.0
+      }, {
+         "id" : 221124,
+         "duration" : "1hour",
+         "price" : 2.0
+      }, {
+         "id" : 221125,
+         "duration" : "1day",
+         "price" : 20.0
+      }, {
+         "id" : 221126,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 221127,
+         "duration" : "1week"
+      }, {
+         "id" : 221128,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221129,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 221130,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 221131,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100291,
+      "title" : "Ulm Hbf P2 Ulm Hbf P2 Parkplatz",
+      "station" : {
+         "id" : 6323,
+         "name" : "Ulm Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "199",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkplatz Ulm Hauptbahnhof",
+      "nameDisplay" : "Ulm Hbf P2 Parkplatz",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.983573,
+         "latitude" : 48.401078
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000170.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Ulm",
+         "postalCode" : "89073",
+         "street" : "Friedrich-Ebert-Straße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "177",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : true,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : true,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffDiscount" : "Bonierung an der DB Information oder im DB Reisezentrum. Zahlung anschließend am Kassenautomaten. Rabattierung mit BahnCard direkt am Kassenautomaten.",
+         "tariffFreeParkingTime" : "nein",
+         "tariffDiscountEn" : "Reduction from the DB Information or the DB Reisezentrum (travel centre). Then pay at the pay station. BahnCard discount available directly at the pay station.",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA), EC-Karte, P Card",
+         "tariffPointOfSale" : "Park&Rail-Karten erhältlich an allen Verkaufsstellen der Deutschen Bahn (außer Internet).",
+         "tariffPointOfSaleEn" : "Park&Rail cards available from all Deutsche Bahn points of sale (except online).  ",
+         "tariffPaymentCustomerCards" : "P Card",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA), EC-Card, P Card"
+      },
+      "tariffPrices" : [ {
+         "id" : 221132,
+         "duration" : "20min"
+      }, {
+         "id" : 221133,
+         "duration" : "30min"
+      }, {
+         "id" : 221134,
+         "duration" : "1hour",
+         "price" : 2.2
+      }, {
+         "id" : 221135,
+         "duration" : "1day",
+         "price" : 18.0
+      }, {
+         "id" : 221136,
+         "duration" : "1dayDiscount",
+         "price" : 15.0
+      }, {
+         "id" : 221137,
+         "duration" : "1week"
+      }, {
+         "id" : 221138,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221139,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 221140,
+         "duration" : "1monthLongTerm",
+         "price" : 150.0
+      }, {
+         "id" : 221141,
+         "duration" : "1monthReservation",
+         "price" : 250.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100292,
+      "title" : "Völklingen P1 Parkplatz Bahnhof Völklingen",
+      "station" : {
+         "id" : 6445,
+         "name" : "Völklingen"
+      },
+      "label" : "P1",
+      "spaceNumber" : "344",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Völklingen",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 6.849948,
+         "latitude" : 49.248528
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000175.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Völklingen",
+         "postalCode" : "66333",
+         "street" : "Rathausstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "26",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "380",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 10 days or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 10 Tage oder Monatsparkschein",
+         "tarifNotesEn" : "Covered parking spaces.",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffNotes" : "Stellplätze sind überdacht.",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 221142,
+         "duration" : "20min"
+      }, {
+         "id" : 221143,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 221144,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 221145,
+         "duration" : "1day",
+         "price" : 4.5
+      }, {
+         "id" : 221146,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 221147,
+         "duration" : "1week",
+         "price" : 18.0
+      }, {
+         "id" : 221148,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221149,
+         "duration" : "1monthVendingMachine",
+         "price" : 33.0
+      }, {
+         "id" : 221150,
+         "duration" : "1monthLongTerm",
+         "price" : 33.0
+      }, {
+         "id" : 221151,
+         "duration" : "1monthReservation",
+         "price" : 60.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100294,
+      "title" : "Wächtersbach P1 Parkplatz Bahnhof Wächtersbach links",
+      "station" : {
+         "id" : 6460,
+         "name" : "Wächtersbach"
+      },
+      "label" : "P1",
+      "spaceNumber" : "231",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Wächtersbach links",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.295895,
+         "latitude" : 50.254544
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8006132.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Wächtersbach",
+         "postalCode" : "63607",
+         "street" : "Am Bahnhof"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "46",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "clearanceHeight" : "300",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 11 days or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 11 Tage oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 221152,
+         "duration" : "20min"
+      }, {
+         "id" : 221153,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 221154,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 221155,
+         "duration" : "1day",
+         "price" : 2.8
+      }, {
+         "id" : 221156,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 221157,
+         "duration" : "1week",
+         "price" : 14.0
+      }, {
+         "id" : 221158,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221159,
+         "duration" : "1monthVendingMachine",
+         "price" : 27.0
+      }, {
+         "id" : 221160,
+         "duration" : "1monthLongTerm",
+         "price" : 27.0
+      }, {
+         "id" : 221161,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100295,
+      "title" : "Wächtersbach P2 Parkplatz Bahnhof Wächtersbach rechts",
+      "station" : {
+         "id" : 6460,
+         "name" : "Wächtersbach"
+      },
+      "label" : "P2",
+      "spaceNumber" : "200",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Wächtersbach rechts",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.294769,
+         "latitude" : 50.253615
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8006132.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Wächtersbach",
+         "postalCode" : "63607",
+         "street" : "Main-Kinzig-Straße/Bahnhofstraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "280",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "clearanceHeight" : "300",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 11 days or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 11 Tage oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 221162,
+         "duration" : "20min"
+      }, {
+         "id" : 221163,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 221164,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 221165,
+         "duration" : "1day",
+         "price" : 2.8
+      }, {
+         "id" : 221166,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 221167,
+         "duration" : "1week",
+         "price" : 14.0
+      }, {
+         "id" : 221168,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221169,
+         "duration" : "1monthVendingMachine",
+         "price" : 27.0
+      }, {
+         "id" : 221170,
+         "duration" : "1monthLongTerm",
+         "price" : 27.0
+      }, {
+         "id" : 221171,
+         "duration" : "1monthReservation",
+         "price" : 50.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100296,
+      "title" : "Wächtersbach P3 Parkplatz Bahnhof Wächtersbach gegenüber",
+      "station" : {
+         "id" : 6460,
+         "name" : "Wächtersbach"
+      },
+      "label" : "P3",
+      "spaceNumber" : "232",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Wächtersbach gegenüber",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.296179,
+         "latitude" : 50.255227
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8006132.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Wächtersbach",
+         "postalCode" : "63607",
+         "street" : "Bahnhofstraße"
+      },
+      "distance" : "100-149",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "45",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "300",
+         "clearanceHeight" : "300",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 11 days or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 11 Tage oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 221172,
+         "duration" : "20min"
+      }, {
+         "id" : 221173,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 221174,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 221175,
+         "duration" : "1day",
+         "price" : 2.8
+      }, {
+         "id" : 221176,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 221177,
+         "duration" : "1week",
+         "price" : 14.0
+      }, {
+         "id" : 221178,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221179,
+         "duration" : "1monthVendingMachine",
+         "price" : 27.0
+      }, {
+         "id" : 221180,
+         "duration" : "1monthLongTerm",
+         "price" : 27.0
+      }, {
+         "id" : 221181,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100293,
+      "title" : "Warnemünde P1 Vorplatz Bahnhof Warnemünde",
+      "station" : {
+         "id" : 6545,
+         "name" : "Warnemünde"
+      },
+      "label" : "P1",
+      "spaceNumber" : "201",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Bahnhofsvorplatz",
+      "nameDisplay" : "Vorplatz Bahnhof Warnemünde",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 12.090144,
+         "latitude" : 54.17734
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8013236.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Warnemünde",
+         "postalCode" : "18119",
+         "street" : "Am Bahnhof"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "15",
+      "numberHandicapedPlaces" : "1",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "990",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 day",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 1 Tag",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 221182,
+         "duration" : "20min"
+      }, {
+         "id" : 221183,
+         "duration" : "30min"
+      }, {
+         "id" : 221184,
+         "duration" : "1hour",
+         "price" : 2.0
+      }, {
+         "id" : 221185,
+         "duration" : "1day",
+         "price" : 14.0
+      }, {
+         "id" : 221186,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 221187,
+         "duration" : "1week"
+      }, {
+         "id" : 221188,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221189,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 221190,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 221191,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100298,
+      "title" : "Weiden (Oberpf) P1 Parkplatz Bahnhof Weiden (Oberpf)",
+      "station" : {
+         "id" : 6597,
+         "name" : "Weiden (Oberpf)"
+      },
+      "label" : "P1",
+      "spaceNumber" : "402",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Weiden (Oberpf)",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 12.154545,
+         "latitude" : 49.67054
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000204.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Weiden in der Oberpfalz",
+         "postalCode" : "92637",
+         "street" : "Bahnhofstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "18",
+      "numberHandicapedPlaces" : "2",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 221192,
+         "duration" : "20min"
+      }, {
+         "id" : 221193,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 221194,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 221195,
+         "duration" : "1day",
+         "price" : 4.0
+      }, {
+         "id" : 221196,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 221197,
+         "duration" : "1week",
+         "price" : 16.0
+      }, {
+         "id" : 221198,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221199,
+         "duration" : "1monthVendingMachine",
+         "price" : 33.0
+      }, {
+         "id" : 221200,
+         "duration" : "1monthLongTerm",
+         "price" : 33.0
+      }, {
+         "id" : 221201,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100299,
+      "title" : "Weiden (Oberpf) P2 Parkplatz Bahnhof Weiden (Oberpf) rechts",
+      "station" : {
+         "id" : 6597,
+         "name" : "Weiden (Oberpf)"
+      },
+      "label" : "P2",
+      "spaceNumber" : "403",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Weiden (Oberpf) rechts",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 12.154471,
+         "latitude" : 49.671179
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000204.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Weiden in der Oberpfalz",
+         "postalCode" : "92637",
+         "street" : "Bahnhofstraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "39",
+      "numberHandicapedPlaces" : "2",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 221202,
+         "duration" : "20min"
+      }, {
+         "id" : 221203,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 221204,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 221205,
+         "duration" : "1day",
+         "price" : 3.6
+      }, {
+         "id" : 221206,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 221207,
+         "duration" : "1week",
+         "price" : 14.4
+      }, {
+         "id" : 221208,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221209,
+         "duration" : "1monthVendingMachine",
+         "price" : 33.0
+      }, {
+         "id" : 221210,
+         "duration" : "1monthLongTerm",
+         "price" : 33.0
+      }, {
+         "id" : 221211,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100300,
+      "title" : "Weilheim (Oberbay) P1 Parkplatz Bahnhof Weilheim links",
+      "station" : {
+         "id" : 6616,
+         "name" : "Weilheim (Oberbay)"
+      },
+      "label" : "P1",
+      "spaceNumber" : "202",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Weilheim links",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 11.142709,
+         "latitude" : 47.844385
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000220.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Weilheim in Oberbayern",
+         "postalCode" : "82362",
+         "street" : "Bahnhofstraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "22",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 1 week",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 1 Woche",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 221212,
+         "duration" : "20min"
+      }, {
+         "id" : 221213,
+         "duration" : "30min"
+      }, {
+         "id" : 221214,
+         "duration" : "1hour",
+         "price" : 0.6
+      }, {
+         "id" : 221215,
+         "duration" : "1day",
+         "price" : 2.4
+      }, {
+         "id" : 221216,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 221217,
+         "duration" : "1week",
+         "price" : 9.6
+      }, {
+         "id" : 221218,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221219,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 221220,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 221221,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100301,
+      "title" : "Weilheim (Oberbay) P2 Parkplatz Bahnhof Weilheim Bahnhofsallee",
+      "station" : {
+         "id" : 6616,
+         "name" : "Weilheim (Oberbay)"
+      },
+      "label" : "P2",
+      "spaceNumber" : "203",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Weilheim Bahnhofsallee",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 11.144531,
+         "latitude" : 47.844839
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000220.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Weilheim in Oberbayern",
+         "postalCode" : "82362",
+         "street" : "Bahnhofsallee 2c"
+      },
+      "distance" : "100-149",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "55",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 221222,
+         "duration" : "20min"
+      }, {
+         "id" : 221223,
+         "duration" : "30min"
+      }, {
+         "id" : 221224,
+         "duration" : "1hour",
+         "price" : 0.6
+      }, {
+         "id" : 221225,
+         "duration" : "1day",
+         "price" : 2.4
+      }, {
+         "id" : 221226,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 221227,
+         "duration" : "1week",
+         "price" : 9.6
+      }, {
+         "id" : 221228,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221229,
+         "duration" : "1monthVendingMachine",
+         "price" : 27.0
+      }, {
+         "id" : 221230,
+         "duration" : "1monthLongTerm",
+         "price" : 35.0
+      }, {
+         "id" : 221231,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100302,
+      "title" : "Weimar P1 Parkplatz Bahnhof Weimar rechts",
+      "station" : {
+         "id" : 6617,
+         "name" : "Weimar"
+      },
+      "label" : "P1",
+      "spaceNumber" : "205",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Weimar rechts",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 11.327295,
+         "latitude" : 50.991133
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8010366.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Weimar",
+         "postalCode" : "99423",
+         "street" : "Schopenhauerstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "18",
+      "numberHandicapedPlaces" : "1",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 3 days",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 3 Tage",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 221232,
+         "duration" : "20min"
+      }, {
+         "id" : 221233,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 221234,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 221235,
+         "duration" : "1day",
+         "price" : 4.0
+      }, {
+         "id" : 221236,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 221237,
+         "duration" : "1week"
+      }, {
+         "id" : 221238,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221239,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 221240,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 221241,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100303,
+      "title" : "Weimar P2 Parkplatz Bahnhof Weimar links",
+      "station" : {
+         "id" : 6617,
+         "name" : "Weimar"
+      },
+      "label" : "P2",
+      "spaceNumber" : "204",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Weimar links",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 11.324952,
+         "latitude" : 50.991266
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8010366.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Weimar",
+         "postalCode" : "99423",
+         "street" : "Schopenhauerstraße"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "39",
+      "numberHandicapedPlaces" : "1",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "275",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks from the parking ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 221242,
+         "duration" : "20min"
+      }, {
+         "id" : 221243,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 221244,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 221245,
+         "duration" : "1day",
+         "price" : 4.0
+      }, {
+         "id" : 221246,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 221247,
+         "duration" : "1week",
+         "price" : 16.0
+      }, {
+         "id" : 221248,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221249,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 221250,
+         "duration" : "1monthLongTerm",
+         "price" : 50.0
+      }, {
+         "id" : 221251,
+         "duration" : "1monthReservation",
+         "price" : 80.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100304,
+      "title" : "Wiesbaden Hbf P1 Vorplatz Wiesbaden Hbf Ostseite",
+      "station" : {
+         "id" : 6744,
+         "name" : "Wiesbaden Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "207",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Vorplatz Wiesbaden Hbf Ostseite",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.245044,
+         "latitude" : 50.070549
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000250.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Wiesbaden",
+         "postalCode" : "65189",
+         "street" : "Salzbachstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "53",
+      "numberHandicapedPlaces" : "2",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "250",
+         "clearanceHeight" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 221252,
+         "duration" : "20min"
+      }, {
+         "id" : 221253,
+         "duration" : "30min",
+         "price" : 0.8
+      }, {
+         "id" : 221254,
+         "duration" : "1hour",
+         "price" : 1.6
+      }, {
+         "id" : 221255,
+         "duration" : "1day",
+         "price" : 4.0
+      }, {
+         "id" : 221256,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 221257,
+         "duration" : "1week",
+         "price" : 20.0
+      }, {
+         "id" : 221258,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221259,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 221260,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 221261,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100305,
+      "title" : "Wiesbaden Hbf P2 Parkplatz Wiesbaden Hbf Westseite",
+      "station" : {
+         "id" : 6744,
+         "name" : "Wiesbaden Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "308",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Wiesbaden Hbf Westseite",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.242618,
+         "latitude" : 50.070003
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000250.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Wiesbaden",
+         "postalCode" : "65189",
+         "street" : "Klingholzstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "151",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 221272,
+         "duration" : "20min"
+      }, {
+         "id" : 221273,
+         "duration" : "30min",
+         "price" : 0.8
+      }, {
+         "id" : 221274,
+         "duration" : "1hour",
+         "price" : 1.6
+      }, {
+         "id" : 221275,
+         "duration" : "1day",
+         "price" : 4.0
+      }, {
+         "id" : 221276,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 221277,
+         "duration" : "1week",
+         "price" : 20.0
+      }, {
+         "id" : 221278,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221279,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 221280,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 221281,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100306,
+      "title" : "Wiesbaden Hbf P3 Parkplatz Wiesbaden Hbf Ostseite",
+      "station" : {
+         "id" : 6744,
+         "name" : "Wiesbaden Hbf"
+      },
+      "label" : "P3",
+      "spaceNumber" : "391",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Wiesbaden Hbf Ostseite",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 8.245424,
+         "latitude" : 50.069028
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000250.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Wiesbaden",
+         "postalCode" : "65189",
+         "street" : "Salzbachstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "107",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "500",
+         "clearanceHeight" : "500",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 221262,
+         "duration" : "20min"
+      }, {
+         "id" : 221263,
+         "duration" : "30min",
+         "price" : 0.6
+      }, {
+         "id" : 221264,
+         "duration" : "1hour",
+         "price" : 1.2
+      }, {
+         "id" : 221265,
+         "duration" : "1day",
+         "price" : 3.9
+      }, {
+         "id" : 221266,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 221267,
+         "duration" : "1week",
+         "price" : 19.5
+      }, {
+         "id" : 221268,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221269,
+         "duration" : "1monthVendingMachine",
+         "price" : 60.0
+      }, {
+         "id" : 221270,
+         "duration" : "1monthLongTerm",
+         "price" : 60.0
+      }, {
+         "id" : 221271,
+         "duration" : "1monthReservation",
+         "price" : 90.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100307,
+      "title" : "Wittlich Hbf P1 Parkplatz Wittlich Hbf",
+      "station" : {
+         "id" : 6834,
+         "name" : "Wittlich Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "209",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Wittlich Hbf",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 6.943295,
+         "latitude" : 49.973341
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000379.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Wittlich",
+         "postalCode" : "54516",
+         "street" : "Bahnhofstraße"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "105",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "380",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 11 days or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 11 Tage oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 221282,
+         "duration" : "20min"
+      }, {
+         "id" : 221283,
+         "duration" : "30min",
+         "price" : 0.5
+      }, {
+         "id" : 221284,
+         "duration" : "1hour"
+      }, {
+         "id" : 221285,
+         "duration" : "1day",
+         "price" : 1.0
+      }, {
+         "id" : 221286,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 221287,
+         "duration" : "1week",
+         "price" : 5.0
+      }, {
+         "id" : 221288,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221289,
+         "duration" : "1monthVendingMachine",
+         "price" : 10.0
+      }, {
+         "id" : 221290,
+         "duration" : "1monthLongTerm",
+         "price" : 10.0
+      }, {
+         "id" : 221291,
+         "duration" : "1monthReservation",
+         "price" : 15.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100308,
+      "title" : "Wolfsburg Hbf P1 Wolfsburg Hbf P1 Parkdeck",
+      "station" : {
+         "id" : 6859,
+         "name" : "Wolfsburg Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "345",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Parkdeck Wolfsburg Hauptbahnhof",
+      "nameDisplay" : "Wolfsburg Hbf P1 Parkdeck",
+      "spaceType" : "Parkdeck",
+      "spaceTypeEn" : "Parking deck",
+      "spaceTypeName" : "Parkhaus",
+      "geoLocation" : {
+         "longitude" : 10.786246,
+         "latitude" : 52.428982
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8006552.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Wolfsburg",
+         "postalCode" : "38440",
+         "street" : "Willy-Brandt-Platz"
+      },
+      "distance" : "<50",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "190",
+      "numberHandicapedPlaces" : "4",
+      "isSpecialProductDb" : true,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "365",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : true,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : true,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffSpecialEn" : "Monthly tariff applies only to Bahn customers. ",
+         "tariffPointOfSaleEn" : "Park&Rail cards available from all Deutsche Bahn points of sale (except online).  ",
+         "tariffPaymentCustomerCards" : "P Card",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffDiscount" : "Rabattierung mit BahnCard direkt am Kassenautomaten. Bonierung des Einfahrtstickets im DB Reisezentrum Wolfsburg. Bitte beachten Sie die Öffnungszeiten des Reisezentrums.",
+         "tariffFreeParkingTime" : "nein",
+         "tariffSpecial" : "Monatstarif gilt nur für Bahnkunden.",
+         "tariffDiscountEn" : "BahnCard discount available directly at the pay station. Reduction on the entrance ticket in the Wolfsburg DB Reisezentrum (travel centre). Please note the travel centre's opening hours. ",
+         "tariffPaymentOptions" : "Münzen, Scheine, Kreditkarten (AMEX, MasterCard, VISA), P Card",
+         "tariffPointOfSale" : "Park&Rail-Karten erhältlich an allen Verkaufsstellen der Deutschen Bahn (außer Internet).",
+         "tariffPaymentOptionsEn" : "Coins, bills, credit cards (AMEX, MasterCard, VISA), P Card"
+      },
+      "tariffPrices" : [ {
+         "id" : 221292,
+         "duration" : "20min"
+      }, {
+         "id" : 221293,
+         "duration" : "30min"
+      }, {
+         "id" : 221294,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 221295,
+         "duration" : "1day",
+         "price" : 6.0
+      }, {
+         "id" : 221296,
+         "duration" : "1dayDiscount",
+         "price" : 4.0
+      }, {
+         "id" : 221297,
+         "duration" : "1week"
+      }, {
+         "id" : 221298,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221299,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 221300,
+         "duration" : "1monthLongTerm",
+         "price" : 28.0
+      }, {
+         "id" : 221301,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100309,
+      "title" : "Wolfsburg Hbf P2 Wolfsburg Hbf P2 Tiefgarage Hbf / Kino",
+      "station" : {
+         "id" : 6859,
+         "name" : "Wolfsburg Hbf"
+      },
+      "label" : "P2",
+      "spaceNumber" : "352",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Tiefgarage Hauptbahnhof / Kino",
+      "nameDisplay" : "Wolfsburg Hbf P2 Tiefgarage Hbf / Kino",
+      "spaceType" : "Tiefgarage",
+      "spaceTypeEn" : "Underground car park",
+      "spaceTypeName" : "Tiefgarage",
+      "geoLocation" : {
+         "longitude" : 10.786892,
+         "latitude" : 52.428503
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8006552.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Wolfsburg",
+         "postalCode" : "38440",
+         "street" : "Willy-Brandt-Platz"
+      },
+      "distance" : "50-99",
+      "facilityType" : "Schrankenanlage",
+      "facilityTypeEn" : "Barrier system",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "113",
+      "numberHandicapedPlaces" : "2",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "clearanceWidth" : "229.99999999999997",
+         "clearanceHeight" : "200",
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffPaymentOptions" : "Münzen, Scheine",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Coins bills"
+      },
+      "tariffPrices" : [ {
+         "id" : 221302,
+         "duration" : "20min"
+      }, {
+         "id" : 221303,
+         "duration" : "30min"
+      }, {
+         "id" : 221304,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 221305,
+         "duration" : "1day",
+         "price" : 6.0
+      }, {
+         "id" : 221306,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 221307,
+         "duration" : "1week"
+      }, {
+         "id" : 221308,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221309,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 221310,
+         "duration" : "1monthLongTerm",
+         "price" : 90.0
+      }, {
+         "id" : 221311,
+         "duration" : "1monthReservation",
+         "price" : 140.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100311,
+      "title" : "Wuppertal-Oberbarmen P1 Parkplatz Bahnhof Wuppertal-Oberbarmen",
+      "station" : {
+         "id" : 6928,
+         "name" : "Wuppertal-Oberbarmen"
+      },
+      "label" : "P1",
+      "spaceNumber" : "281",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Wuppertal-Oberbarmen",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 7.220542,
+         "latitude" : 51.274129
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8006719.pdf",
+      "operator" : "PRBL - Parkraumbewirtschaftung Linne",
+      "address" : {
+         "cityName" : "Wuppertal",
+         "postalCode" : "42277",
+         "street" : "Rosenau 10"
+      },
+      "distance" : "<50",
+      "facilityType" : "keine",
+      "facilityTypeEn" : "none",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "12",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffPaymentOptions" : "*Monatskarten: Dauerparkvertrag über clinne@t-online.de zu beantragen.",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "*Monthly ticket: Application form for season parking available from: clinne@t-online.de."
+      },
+      "tariffPrices" : [ {
+         "id" : 221312,
+         "duration" : "20min"
+      }, {
+         "id" : 221313,
+         "duration" : "30min"
+      }, {
+         "id" : 221314,
+         "duration" : "1hour"
+      }, {
+         "id" : 221315,
+         "duration" : "1day"
+      }, {
+         "id" : 221316,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 221317,
+         "duration" : "1week"
+      }, {
+         "id" : 221318,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221319,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 221320,
+         "duration" : "1monthLongTerm",
+         "price" : 30.0
+      }, {
+         "id" : 221321,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100312,
+      "title" : "Wuppertal-Oberbarmen P2 Parkplatz Bahnhof Wuppertal-Oberbarmen",
+      "station" : {
+         "id" : 6928,
+         "name" : "Wuppertal-Oberbarmen"
+      },
+      "label" : "P2",
+      "spaceNumber" : "280",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Wuppertal-Oberbarmen",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 7.220713,
+         "latitude" : 51.274357
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8006719.pdf",
+      "operator" : "PRBL - Parkraumbewirtschaftung Linne",
+      "address" : {
+         "cityName" : "Wuppertal",
+         "postalCode" : "42277",
+         "street" : "Rosenau 10"
+      },
+      "distance" : "<50",
+      "facilityType" : "keine",
+      "facilityTypeEn" : "none",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "21",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffPaymentOptions" : "*Monatskarten: Dauerparkvertrag über clinne@t-online.de zu beantragen.",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "*Monthly ticket: Application form for season parking available from: clinne@t-online.de."
+      },
+      "tariffPrices" : [ {
+         "id" : 221322,
+         "duration" : "20min"
+      }, {
+         "id" : 221323,
+         "duration" : "30min"
+      }, {
+         "id" : 221324,
+         "duration" : "1hour"
+      }, {
+         "id" : 221325,
+         "duration" : "1day"
+      }, {
+         "id" : 221326,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 221327,
+         "duration" : "1week"
+      }, {
+         "id" : 221328,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221329,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 221330,
+         "duration" : "1monthLongTerm",
+         "price" : 30.0
+      }, {
+         "id" : 221331,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100313,
+      "title" : "Wuppertal-Oberbarmen P3 Tiefgarage Bahnhof Wuppertal-Oberbarmen",
+      "station" : {
+         "id" : 6928,
+         "name" : "Wuppertal-Oberbarmen"
+      },
+      "label" : "P3",
+      "spaceNumber" : "282",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Tiefgarage Bahnhof Wuppertal-Oberbarmen",
+      "spaceType" : "Tiefgarage",
+      "spaceTypeEn" : "Underground car park",
+      "spaceTypeName" : "Tiefgarage",
+      "geoLocation" : {
+         "longitude" : 7.220752,
+         "latitude" : 51.274246
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8006719.pdf",
+      "operator" : "PRBL - Parkraumbewirtschaftung Linne",
+      "address" : {
+         "cityName" : "Wuppertal",
+         "postalCode" : "42277",
+         "street" : "Rosenau 10"
+      },
+      "distance" : "<50",
+      "facilityType" : "keine",
+      "facilityTypeEn" : "none",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "32",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffPaymentOptions" : "*Monatskarten: Dauerparkvertrag über clinne@t-online.de zu beantragen.",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "*Monthly ticket: Application form for season parking available from: clinne@t-online.de."
+      },
+      "tariffPrices" : [ {
+         "id" : 221332,
+         "duration" : "20min"
+      }, {
+         "id" : 221333,
+         "duration" : "30min"
+      }, {
+         "id" : 221334,
+         "duration" : "1hour"
+      }, {
+         "id" : 221335,
+         "duration" : "1day"
+      }, {
+         "id" : 221336,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 221337,
+         "duration" : "1week"
+      }, {
+         "id" : 221338,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221339,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 221340,
+         "duration" : "1monthLongTerm",
+         "price" : 40.0
+      }, {
+         "id" : 221341,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100297,
+      "title" : "Würzburg Hbf P1 Vorplatz Würzburg Hbf",
+      "station" : {
+         "id" : 6945,
+         "name" : "Würzburg Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "213",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "name" : "Bahnhofsvorplatz",
+      "nameDisplay" : "Vorplatz Würzburg Hbf",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 9.936565,
+         "latitude" : 49.801156
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8000260.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Würzburg",
+         "postalCode" : "97070",
+         "street" : "Bahnhofplatz"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "79",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : false
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 4 hours",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 4 Stunden",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 221342,
+         "duration" : "20min"
+      }, {
+         "id" : 221343,
+         "duration" : "30min",
+         "price" : 1.0
+      }, {
+         "id" : 221344,
+         "duration" : "1hour",
+         "price" : 2.0
+      }, {
+         "id" : 221345,
+         "duration" : "1day"
+      }, {
+         "id" : 221346,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 221347,
+         "duration" : "1week"
+      }, {
+         "id" : 221348,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221349,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 221350,
+         "duration" : "1monthLongTerm"
+      }, {
+         "id" : 221351,
+         "duration" : "1monthReservation"
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100314,
+      "title" : "Wurzen P1 Parkplatz Bahnhof Wurzen",
+      "station" : {
+         "id" : 6950,
+         "name" : "Wurzen"
+      },
+      "label" : "P1",
+      "spaceNumber" : "236",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Bahnhof Wurzen",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 12.739737,
+         "latitude" : 51.364743
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8013361.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Wurzen",
+         "postalCode" : "04808",
+         "street" : "Am Bahnhof"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "70",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : true,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks or monthly ticket from the ticket machine",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA, MasterCard) oder EC-Karte.",
+         "tariffMaxParkingTime" : "Max. 2 Wochen oder Monatsparkschein",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard."
+      },
+      "tariffPrices" : [ {
+         "id" : 221352,
+         "duration" : "20min"
+      }, {
+         "id" : 221353,
+         "duration" : "30min",
+         "price" : 0.5
+      }, {
+         "id" : 221354,
+         "duration" : "1hour",
+         "price" : 1.0
+      }, {
+         "id" : 221355,
+         "duration" : "1day",
+         "price" : 3.0
+      }, {
+         "id" : 221356,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 221357,
+         "duration" : "1week",
+         "price" : 12.0
+      }, {
+         "id" : 221358,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221359,
+         "duration" : "1monthVendingMachine",
+         "price" : 25.0
+      }, {
+         "id" : 221360,
+         "duration" : "1monthLongTerm",
+         "price" : 25.0
+      }, {
+         "id" : 221361,
+         "duration" : "1monthReservation",
+         "price" : 40.0
+      } ]
+   }, {
+      "type" : "space",
+      "id" : 100315,
+      "title" : "Zwickau (Sachs) Hbf P1 Parkplatz Zwickau Hbf",
+      "station" : {
+         "id" : 7068,
+         "name" : "Zwickau (Sachs) Hbf"
+      },
+      "label" : "P1",
+      "spaceNumber" : "398",
+      "responsibility" : "dbbahnpark",
+      "source" : "dbbahnpark",
+      "nameDisplay" : "Parkplatz Zwickau Hbf",
+      "spaceType" : "Parkplatz",
+      "spaceTypeEn" : "Surface car park",
+      "spaceTypeName" : "Parkplatz",
+      "geoLocation" : {
+         "longitude" : 12.47656,
+         "latitude" : 50.715451
+      },
+      "url" : "http://www.dbbahnpark.info/content/fahrplanauskunft/bahnpark/pdf/8010397.pdf",
+      "operator" : "Contipark Parkgaragengesellschaft mbH",
+      "operatorUrl" : "www.contipark.de",
+      "address" : {
+         "cityName" : "Zwickau",
+         "postalCode" : "08056",
+         "street" : "Am Bahnhof 1"
+      },
+      "distance" : "<50",
+      "facilityType" : "Parkscheinautomat",
+      "facilityTypeEn" : "Parking ticket machine",
+      "openingHours" : "24 Stunden, 7 Tage",
+      "openingHoursEn" : "24 hours a day, 7 days a week",
+      "numberParkingPlaces" : "23",
+      "numberHandicapedPlaces" : "0",
+      "isSpecialProductDb" : false,
+      "isOutOfService" : false,
+      "spaceInfo" : {
+         "allowedPropulsions" : "Alle",
+         "chargingStation" : "nein"
+      },
+      "spaceFlags" : {
+      },
+      "tariffFlags" : {
+         "isDiscountDbBahnCard" : false,
+         "isMonthVendingMachine" : false,
+         "isDiscountDbBahnComfort" : false,
+         "isDiscountDbParkAndRail" : false,
+         "isMonthParkAndRide" : false,
+         "isMonthSeason" : true
+      },
+      "tariffInfo" : {
+         "tariffFreeParkingTime" : "nein",
+         "tariffMaxParkingTimeEn" : "Max. 2 weeks from the parking ticket machine",
+         "tariffPaymentMobile" : "App DB BahnPark",
+         "tariffPaymentOptions" : "Zahlung am Automaten in Münzen, mit Kreditkarte (AMEX, VISA oder MasterCard) oder EC-Karte. Mobile Zahlung per App DB BahnPark: Auf app.servipark.de registrieren, App laden aus dem Store, appparken!",
+         "tariffMaxParkingTime" : "Max. 2 Wochen am Automaten",
+         "tariffFreeParkingTimeEn" : "nein",
+         "tariffPaymentOptionsEn" : "Payment at ticket machine: coins, credit card (AMEX, VISA, MasterCard), or MaestroCard.  Mobile payment: register on app.servipark.de then load the app DB BahnPark from the store."
+      },
+      "tariffPrices" : [ {
+         "id" : 221362,
+         "duration" : "20min"
+      }, {
+         "id" : 221363,
+         "duration" : "30min"
+      }, {
+         "id" : 221364,
+         "duration" : "1hour",
+         "price" : 0.5
+      }, {
+         "id" : 221365,
+         "duration" : "1day",
+         "price" : 3.0
+      }, {
+         "id" : 221366,
+         "duration" : "1dayDiscount"
+      }, {
+         "id" : 221367,
+         "duration" : "1week",
+         "price" : 15.0
+      }, {
+         "id" : 221368,
+         "duration" : "1weekDiscount"
+      }, {
+         "id" : 221369,
+         "duration" : "1monthVendingMachine"
+      }, {
+         "id" : 221370,
+         "duration" : "1monthLongTerm",
+         "price" : 55.0
+      }, {
+         "id" : 221371,
+         "duration" : "1monthReservation",
+         "price" : 70.0
+      } ]
+   } ]
+}


### PR DESCRIPTION
Currently using `ParkingSpace` type semantics, which is for a single parking space, though this data is actually for (approximate) parking capacity for a single lot.