### PR TITLE
Enforce not using deprecated NoFlo APIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: node_js
 node_js:
 - '8'
 dist: trusty
+env:
+  - NOFLO_FATAL_DEPRECATED=true

--- a/graphs/architecture.fbp
+++ b/graphs/architecture.fbp
@@ -1,5 +1,7 @@
 '[{id,schema}, ..]' -> CONFIG server(OfferingServer)
 
+# @runtime msgflo
+
 # Parking
 server REQUEST -> parkingProvider(DBahnPark) RESPONSE -> RESPONSE server
 parkingProvider ERROR -> FAILED server

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "fbp": "^1.5.0",
     "noflo": "^0.8.5",
     "noflo-core": "^0.4.0",
-    "noflo-filesystem": "^1.1.1",
+    "noflo-filesystem": "^1.2.1",
     "noflo-nodejs": "^0.8.1",
     "noflo-objects": "^0.3.0",
     "noflo-strings": "^0.3.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "noflo-filesystem": "^1.2.1",
     "noflo-nodejs": "^0.8.1",
     "noflo-objects": "^0.3.0",
-    "noflo-strings": "^0.3.0"
+    "noflo-strings": "^0.3.1"
   },
   "devDependencies": {
     "fbp-spec": "^0.2.1"


### PR DESCRIPTION
Using the env var will make builds fail if this project or any of its dependencies use deprecated NoFlo APIs.